### PR TITLE
feat: .apm scaffold + project 知識 skill 3本（your-quiz-project-knowledge / your-quiz-api / your-quiz-domain）

### DIFF
--- a/.apm/skills/your-quiz-api/SKILL.md
+++ b/.apm/skills/your-quiz-api/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: your-quiz-api
+description: Provides Your Quiz-specific API knowledge for backend implementation. Activate when designing or implementing API endpoints, writing Hono route handlers, handling errors with neverthrow Result types, validating requests with Zod, working with TypeSpec schemas, or looking up the API catalog. Contains the API catalog (8 contexts, 80+ endpoints), Hono/neverthrow/Zod/Cloudflare Workers implementation rules, and prohibited patterns specific to this project.
+license: MIT
+metadata:
+  author: personal
+  version: "0.1.0"
+compatibility: Requires access to docs/project/api-design/ and docs/instructions/project/ in this repository.
+---
+
+# Your Quiz API 知識
+
+## 利用タイミング
+
+- API エンドポイントを設計・実装するとき（高頻度）
+- Hono ルートハンドラを書くとき
+- neverthrow の Result 型でエラーハンドリングするとき
+- Zod スキーマでリクエストバリデーションをするとき
+- TypeSpec スキーマとの整合性を確認するとき
+- API catalog（エンドポイント一覧）を参照するとき
+
+## 確認する入力
+
+- 対象コンテキスト（quiz-management / quiz-learning / user-session / offline-sync）
+- 操作種別（CRUD / コマンド / クエリ / Pub-Sub）
+- 既存 TypeSpec スキーマの参照の有無
+
+## Workflow
+
+1. **API catalog** で対象コンテキストのエンドポイントを確認（`docs/project/api-design/api-catalog/`）
+2. **設計原則** を確認（`docs/project/api-design/design-principles.md`）
+3. **実装ルール** に沿ってハンドラを実装（`references/hono-neverthrow-zod-implementation.md`）
+4. TypeSpec スキーマと整合性を確認してから実装する
+5. neverthrow Result 型でエラーパスをすべて網羅する
+6. Zod で二段階バリデーション（JSON パース → スキーマ検証）を実施する
+
+## 必須技術スタック
+
+| ライブラリ | バージョン | 役割 |
+|-----------|-----------|------|
+| `hono` | `^4.8.10` | API フレームワーク（Cloudflare Workers 最適化）|
+| `neverthrow` | `^8.2.0` | エラーハンドリング（Result 型）|
+| `zod` | `^4.0.14` | バリデーション（TypeScript 統合）|
+| TypeSpec | latest | スキーマファースト定義（API 先行設計）|
+| `openapi-typescript` | latest | TypeSpec → TypeScript 型生成 |
+
+## 禁止パターン
+
+- `as any` の使用 → `as components["schemas"]["Xxx"]` のみ許可
+- 裸の `try-catch` → neverthrow の `Result` 型を使う
+- TypeSpec と整合しない独自スキーマ定義
+- 型なし `new Hono()` → `new Hono<{ Bindings: CloudflareBindings }>()` 必須
+
+## ハンドラ実装パターン（骨格）
+
+```typescript
+// JSONパース → Zodバリデーション → ビジネスロジック → レスポンス
+const handler = async (c: AppContext) => {
+  const jsonResult = await parseJsonSafe(c.req);
+  if (jsonResult.isErr())
+    return c.json({ message: "Invalid JSON", code: jsonResult.error } as ErrorResponse, 400);
+
+  const validated = validateWithZod(schema, jsonResult.value);
+  if (validated.isErr())
+    return c.json({ message: "Invalid body", code: validated.error } as ErrorResponse, 400);
+
+  const result = await domainService.execute(validated.value);
+  return result.match(
+    (data) => c.json(data, 200),
+    (err) => c.json({ message: err.message, code: err.code } as ErrorResponse, 500),
+  );
+};
+```
+
+## API catalog 索引
+
+詳細はすべて `docs/project/api-design/api-catalog/` を参照すること。
+
+| ファイル | コンテキスト | 主な操作 |
+|---------|------------|---------|
+| [01-quiz-management.md](docs/project/api-design/api-catalog/01-quiz-management.md) | Quiz Management | CRUD・承認フロー |
+| [02-quiz-learning.md](docs/project/api-design/api-catalog/02-quiz-learning.md) | Quiz Learning | Deck・セッション・回答 |
+| [03-user-session.md](docs/project/api-design/api-catalog/03-user-session.md) | User Session | 匿名認証・デバイス識別 |
+| [04-offline-sync.md](docs/project/api-design/api-catalog/04-offline-sync.md) | Offline Sync | 同期・競合解決 |
+| [05-search-discovery.md](docs/project/api-design/api-catalog/05-search-discovery.md) | Search | クイズ検索・発見 |
+| [06-integration-patterns.md](docs/project/api-design/api-catalog/06-integration-patterns.md) | Integration | Pub/Sub・WebSocket |
+| [07-common-specs.md](docs/project/api-design/api-catalog/07-common-specs.md) | Common | 共通エラー・認証 |
+| [08-operations.md](docs/project/api-design/api-catalog/08-operations.md) | Operations | ヘルスチェック等 |
+
+- [API 設計 README](docs/project/api-design/README.md): 主要フロー（クイズ回答 / 作成 / 検索）
+- [非機能要件](docs/project/api-design/non-functional-requirements.md): 95%ile ≤ 100ms、同時接続 1000
+
+## 出力形式
+
+- TypeScript コード（Hono + neverthrow + Zod パターン）
+- 型アサーションは `components["schemas"]["Xxx"]` 形式を使用
+- エラーレスポンスは `ErrorResponse` スキーマに統一
+
+## ガードレール
+
+- `docs/project/api-design/**` は変更しない（source of truth）
+- TypeSpec スキーマを先に確認してからハンドラを書く
+- 実装サンプルは `docs/instructions/project/api-implementation-samples.md` を参照
+- 汎用 API 設計の method は `api-contract-design` skill、汎用実装 method は `implementation-guide` skill を参照
+
+## 評価シナリオ
+
+1. 「クイズ一覧を返す API を実装して」→ 02-quiz-learning.md を参照 → ハンドラ実装
+2. 「neverthrow でエラーを返す方法は？」→ references/hono-neverthrow-zod-implementation.md を参照
+3. 「新しいエンドポイントを API catalog に追加したい」→ `api-contract-design` skill（汎用 method）を先に呼ぶ
+4. 「Pub/Sub 連携の設計は？」→ 06-integration-patterns.md と pub-sub-integration.md を参照
+
+## 関連リファレンス
+
+- [references/api-catalog-overview.md](references/api-catalog-overview.md) — カタログ全体サマリー
+- [references/hono-neverthrow-zod-implementation.md](references/hono-neverthrow-zod-implementation.md) — 実装パターン詳細
+- 原典: `docs/instructions/project/api-implementation-rules.md`
+- 原典: `docs/instructions/project/api-libraries-guide.md`
+- 原典: `docs/instructions/project/api-implementation-samples.md`
+- 関連 skill（汎用 method 層）: `api-contract-design`, `implementation-guide`
+- 関連 skill（project 事実層）: `your-quiz-domain`（ドメインモデルと API の橋渡し）

--- a/.apm/skills/your-quiz-api/references/api-catalog-overview.md
+++ b/.apm/skills/your-quiz-api/references/api-catalog-overview.md
@@ -1,0 +1,91 @@
+# API catalog 全体サマリー
+
+詳細は必ず `docs/project/api-design/api-catalog/` の原典ファイルを参照すること。
+
+## コンテキスト別概要
+
+### 01: Quiz Management（クイズ管理）
+
+クイズの CRUD・承認フロー・マスターデータ管理。
+
+主要エンドポイント（例）:
+- `POST /api/quiz/v1/manage/drafts` — 下書き作成
+- `PUT /api/quiz/v1/manage/drafts/:id` — 下書き更新
+- `POST /api/quiz/v1/manage/quizzes/submit` — 承認申請（投稿）
+- `GET /api/quiz/v1/manage/quizzes` — 承認済みクイズ一覧
+
+### 02: Quiz Learning（クイズ学習）
+
+Deck 生成・学習セッション・回答処理・進捗管理。
+
+主要エンドポイント（例）:
+- `GET /api/quiz/v1/learning/published` — 公開クイズ一覧
+- `POST /api/quiz/v1/learning/decks` — Deck 生成
+- `PUT /api/quiz/v1/learning/sessions/:id/answers` — 回答送信
+
+### 03: User Session（ユーザーセッション）
+
+匿名ユーザー識別・JWT 発行・デバイスフィンガープリント。
+
+主要エンドポイント（例）:
+- `POST /api/user/v1/sessions` — セッション作成（匿名）
+- `GET /api/user/v1/sessions/:id` — セッション取得
+
+### 04: Offline Sync（オフライン同期）
+
+オフライン状態でのデータ同期・競合解決。
+
+主要エンドポイント（例）:
+- `POST /api/sync/v1/sessions` — 同期セッション開始
+- `PUT /api/sync/v1/sessions/:id/items` — 同期アイテム送信
+
+### 05: Search & Discovery（検索・発見）
+
+クイズ検索・タグ検索・Deck 生成。
+
+主要エンドポイント（例）:
+- `GET /api/quiz/v1/learning/search` — クイズ検索
+- `POST /api/quiz/v1/learning/decks/from-search` — 検索結果から Deck 生成
+
+### 06: Integration Patterns（統合パターン）
+
+Pub/Sub・WebSocket・イベント駆動連携。
+
+### 07: Common Specs（共通仕様）
+
+全エンドポイント共通の認証（JWT Bearer）・エラーレスポンス形式・レート制限。
+
+**共通エラーレスポンス形式**:
+```json
+{ "message": "string", "code": "string" }
+```
+
+**認証**: `Authorization: Bearer <jwt>` ヘッダ必須（匿名 JWT）
+
+### 08: Operations（運用）
+
+ヘルスチェック・メトリクス・バージョン情報。
+
+## 主要フロー（エンドポイントチェーン）
+
+### クイズ回答フロー
+```
+GET /api/quiz/v1/learning/published
+→ POST /api/quiz/v1/learning/decks
+→ POST /api/user/v1/sessions
+→ PUT /api/quiz/v1/learning/sessions/:id/answers
+```
+
+### クイズ作成フロー
+```
+POST /api/quiz/v1/manage/drafts
+→ PUT /api/quiz/v1/manage/drafts/:id
+→ POST /api/quiz/v1/manage/quizzes/submit
+```
+
+### 検索・学習開始フロー
+```
+GET /api/quiz/v1/learning/search
+→ POST /api/quiz/v1/learning/decks/from-search
+→ POST /api/user/v1/sessions
+```

--- a/.apm/skills/your-quiz-api/references/api-catalog-overview.md
+++ b/.apm/skills/your-quiz-api/references/api-catalog-overview.md
@@ -9,6 +9,7 @@
 クイズの CRUD・承認フロー・マスターデータ管理。
 
 主要エンドポイント（例）:
+
 - `POST /api/quiz/v1/manage/drafts` — 下書き作成
 - `PUT /api/quiz/v1/manage/drafts/:id` — 下書き更新
 - `POST /api/quiz/v1/manage/quizzes/submit` — 承認申請（投稿）
@@ -19,6 +20,7 @@
 Deck 生成・学習セッション・回答処理・進捗管理。
 
 主要エンドポイント（例）:
+
 - `GET /api/quiz/v1/learning/published` — 公開クイズ一覧
 - `POST /api/quiz/v1/learning/decks` — Deck 生成
 - `PUT /api/quiz/v1/learning/sessions/:id/answers` — 回答送信
@@ -28,6 +30,7 @@ Deck 生成・学習セッション・回答処理・進捗管理。
 匿名ユーザー識別・JWT 発行・デバイスフィンガープリント。
 
 主要エンドポイント（例）:
+
 - `POST /api/user/v1/sessions` — セッション作成（匿名）
 - `GET /api/user/v1/sessions/:id` — セッション取得
 
@@ -36,6 +39,7 @@ Deck 生成・学習セッション・回答処理・進捗管理。
 オフライン状態でのデータ同期・競合解決。
 
 主要エンドポイント（例）:
+
 - `POST /api/sync/v1/sessions` — 同期セッション開始
 - `PUT /api/sync/v1/sessions/:id/items` — 同期アイテム送信
 
@@ -44,6 +48,7 @@ Deck 生成・学習セッション・回答処理・進捗管理。
 クイズ検索・タグ検索・Deck 生成。
 
 主要エンドポイント（例）:
+
 - `GET /api/quiz/v1/learning/search` — クイズ検索
 - `POST /api/quiz/v1/learning/decks/from-search` — 検索結果から Deck 生成
 
@@ -56,6 +61,7 @@ Pub/Sub・WebSocket・イベント駆動連携。
 全エンドポイント共通の認証（JWT Bearer）・エラーレスポンス形式・レート制限。
 
 **共通エラーレスポンス形式**:
+
 ```json
 { "message": "string", "code": "string" }
 ```
@@ -69,7 +75,8 @@ Pub/Sub・WebSocket・イベント駆動連携。
 ## 主要フロー（エンドポイントチェーン）
 
 ### クイズ回答フロー
-```
+
+```text
 GET /api/quiz/v1/learning/published
 → POST /api/quiz/v1/learning/decks
 → POST /api/user/v1/sessions
@@ -77,14 +84,16 @@ GET /api/quiz/v1/learning/published
 ```
 
 ### クイズ作成フロー
-```
+
+```text
 POST /api/quiz/v1/manage/drafts
 → PUT /api/quiz/v1/manage/drafts/:id
 → POST /api/quiz/v1/manage/quizzes/submit
 ```
 
 ### 検索・学習開始フロー
-```
+
+```text
 GET /api/quiz/v1/learning/search
 → POST /api/quiz/v1/learning/decks/from-search
 → POST /api/user/v1/sessions

--- a/.apm/skills/your-quiz-api/references/hono-neverthrow-zod-implementation.md
+++ b/.apm/skills/your-quiz-api/references/hono-neverthrow-zod-implementation.md
@@ -1,0 +1,118 @@
+# Hono + neverthrow + Zod 実装パターン
+
+Your Quiz API の実装パターン集。詳細な使用ガイドは `docs/instructions/project/api-libraries-guide.md`、
+実装ルールは `docs/instructions/project/api-implementation-rules.md`、
+サンプルコードは `docs/instructions/project/api-implementation-samples.md` を参照すること。
+
+## Hono セットアップ
+
+```typescript
+import { Hono, type Context } from "hono";
+
+// 必須: CloudflareBindings 型を付与する
+const app = new Hono<{ Bindings: CloudflareBindings }>();
+type AppContext = Context<{ Bindings: CloudflareBindings }>;
+
+// ❌ 禁止: 型なし使用
+// const app = new Hono();
+```
+
+## neverthrow — Result 型
+
+```typescript
+import { Result, ok, err } from "neverthrow";
+
+// Result 型の基本パターン
+type ApiResult<T> = Result<T, string>;
+
+// ✅ 非同期処理
+const fetchData = async (): Promise<Result<Data, string>> => {
+  try {
+    const data = await externalApiCall();
+    return ok(data);
+  } catch {
+    return err("EXTERNAL_API_ERROR");
+  }
+};
+
+// ✅ チェーン処理
+const processData = (input: string): Result<ProcessedData, string> =>
+  validateInput(input)
+    .andThen(parseInput)
+    .andThen(processInput)
+    .map(formatOutput);
+
+// ❌ 禁止: 裸の try-catch でエラーを throw する
+// try { ... } catch (e) { throw new Error("..."); }
+```
+
+## Zod — バリデーション
+
+```typescript
+import { z } from "zod";
+
+// TypeSpec 生成型との整合性を satisfies で保証する
+const createQuizSchema = z.object({
+  question: z.string(),
+  answerType: z.enum(["boolean", "free_text", "single_choice", "multiple_choice"]),
+}) satisfies z.ZodType<components["schemas"]["CreateQuizRequest"]>;
+
+// ❌ 禁止: TypeSpec と整合しない独自スキーマ
+// const bad = z.object({ title: z.string() }); // TypeSpec にないフィールド
+```
+
+## ハンドラ完全パターン
+
+```typescript
+const createQuizHandler = async (c: AppContext) => {
+  // Step 1: JSON パース（neverthrow）
+  const jsonResult = await parseJsonSafe(c.req);
+  if (jsonResult.isErr())
+    return c.json(
+      { message: "Invalid JSON", code: jsonResult.error } as components["schemas"]["ErrorResponse"],
+      400,
+    );
+
+  // Step 2: Zod バリデーション（neverthrow）
+  const validated = validateWithZod(createQuizSchema, jsonResult.value);
+  if (validated.isErr())
+    return c.json(
+      { message: "Invalid body", code: validated.error } as components["schemas"]["ErrorResponse"],
+      400,
+    );
+
+  // Step 3: ドメインサービス呼び出し
+  const result = await quizService.createDraft(validated.value);
+
+  // Step 4: match でレスポンス分岐
+  return result.match(
+    (data) => c.json(data as components["schemas"]["CreateQuizResponse"], 201),
+    (err) =>
+      c.json(
+        { message: err.message, code: err.code } as components["schemas"]["ErrorResponse"],
+        500,
+      ),
+  );
+};
+```
+
+## 型アサーション ルール
+
+```typescript
+// ✅ 許可: TypeSpec 生成型へのアサーション
+return c.json({ message: "Not found", code: "NOT_FOUND" } as ErrorResponse, 404);
+
+// ❌ 禁止: as any
+const data = response as any;
+```
+
+## エラーコード規約
+
+- `INVALID_JSON` — JSON パース失敗
+- `VALIDATION_ERROR` — Zod バリデーション失敗
+- `NOT_FOUND` — リソース不存在
+- `CONFLICT` — 重複・競合
+- `UNAUTHORIZED` — 認証失敗
+- `INTERNAL_ERROR` — サーバー内部エラー
+
+ドメインエラーコードは `docs/project/api-design/api-catalog/07-common-specs.md` を参照。

--- a/.apm/skills/your-quiz-domain/SKILL.md
+++ b/.apm/skills/your-quiz-domain/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: your-quiz-domain
+description: Provides Your Quiz domain model knowledge for DDD implementation. Activate when designing or implementing domain entities, value objects, aggregates, bounded contexts, domain events, or ubiquitous language for the quiz application. Contains the 4 bounded contexts (Quiz Management, Quiz Learning, User Session, Offline Sync), 4 aggregates with their invariants, TypeScript Brand type and AggregateRoot patterns, and pointers to the DDD design artifacts in docs/project/ddd-design/.
+license: MIT
+metadata:
+  author: personal
+  version: "0.1.0"
+compatibility: Requires access to docs/project/ddd-design/ in this repository.
+---
+
+# Your Quiz ドメイン知識
+
+## 利用タイミング
+
+- ドメインエンティティ・値オブジェクト・集約を設計・実装するとき（高頻度）
+- 境界づけられたコンテキストの責務を確認するとき
+- ドメインイベントを設計・実装するとき
+- ユビキタス言語の用語を参照・確認するとき
+- 集約の不変条件・ビジネスルールを実装するとき
+
+## 確認する入力
+
+- 対象コンテキスト（Quiz Management / Quiz Learning / User Session / Offline Sync）
+- 対象の集約・エンティティ・値オブジェクト名
+- 操作（entity 設計 / event 設計 / invariant 確認 / TypeScript 型設計）
+
+## Workflow
+
+1. **対象コンテキスト**を特定（下記の境界コンテキスト索引を参照）
+2. **集約・エンティティの責務**を確認（`docs/project/ddd-design/2.08_aggregate-design/`）
+3. **ユビキタス言語**で用語を統一（`docs/project/ddd-design/2.03_ubiquitous-language/`）
+4. **ドメインイベント**が必要なら catalog を参照（`docs/project/ddd-design/2.10_domain-events-catalog/`）
+5. `references/bounded-contexts-and-aggregates.md` の TypeScript パターンに従い実装する
+
+## 境界づけられたコンテキスト
+
+| コンテキスト | 役割 | 主要集約 | コンテキストマップ上の位置 |
+|------------|------|---------|------------------------|
+| **Quiz Management** | クイズ作成・承認・マスターデータ管理（権威的） | Quiz Aggregate | 上流 → Learning / Offline |
+| **Quiz Learning** | 学習セッション・回答・進捗管理（中核） | Learning Session Aggregate | 下流 ← Management, User Session |
+| **User Session** | 匿名ユーザー識別・セッション管理（支援的） | User Session Aggregate | 上流 → Learning / Offline |
+| **Offline Sync** | オフライン同期・競合解決（技術的） | Sync Session Aggregate | 下流 ← 全コンテキスト |
+
+依存方向: 上流から下流へ。コンテキスト間は ID 参照のみ（集約境界を越えない）。
+
+## 主要集約 サマリー
+
+### Quiz Aggregate（権威的）
+- **責務**: クイズ内容の品質保証・承認フロー・ライフサイクル管理
+- **状態遷移**: 投稿 → 承認 → 公開（強一貫性）
+- **設計決定**: 単一エンティティ集約（クイズ≠回答の分離）
+- 詳細 → `docs/project/ddd-design/2.08_aggregate-design/`
+
+### Learning Session Aggregate（中核）
+- **責務**: 学習体験・回答履歴・学習進捗計算
+- **設計決定**: 複合集約（Session + Answer の一体管理）、結果整合性
+- **パフォーマンス**: 高頻度アクセス、CQRS 的クエリ分離
+- 詳細 → `docs/project/ddd-design/2.08_aggregate-design/`
+
+### User Session Aggregate（支援的）
+- **責務**: 匿名ユーザー識別・セッション管理・作成者権限制御
+- **設計決定**: 軽量集約、プライバシー重視（個人情報なし）
+- **VO**: `DeviceFingerprint`, `CreatorId`
+- 詳細 → `docs/project/ddd-design/2.08_aggregate-design/`
+
+### Sync Session Aggregate（技術的）
+- **責務**: オフライン/オンライン同期・データ競合解決・整合性保証
+- **設計決定**: 技術集約、横断的関心事（全データが同期対象）
+- 詳細 → `docs/project/ddd-design/2.08_aggregate-design/`
+
+## Shared Kernel
+
+- **Common Types**: `QuizId`, `SessionId`, `AnswerId`, `UserId`（Brand 型）
+- **Domain Events**: 共通 `DomainEvent` インターフェース
+- **Error Types**: `DomainError`, `ValidationError`, `BusinessRuleError`, `InvariantViolationError`
+
+## TypeScript 実装パターン（概要）
+
+```typescript
+// 識別子型（Brand 型パターン）
+type QuizId = Brand<string, 'QuizId'>;
+type SessionId = Brand<string, 'SessionId'>;
+
+// 値オブジェクト（不変性・等価性）
+class Question {
+  private constructor(readonly text: string, readonly length: number) {}
+  static create(text: string): Result<Question, ValidationError> { ... }
+  equals(other: Question): boolean { return this.text === other.text; }
+}
+
+// 集約ルート（ドメインイベント収集）
+abstract class AggregateRoot<T> {
+  private domainEvents: DomainEvent[] = [];
+  protected addDomainEvent(event: DomainEvent): void { ... }
+  getDomainEvents(): readonly DomainEvent[] { return [...this.domainEvents]; }
+  clearDomainEvents(): void { this.domainEvents = []; }
+}
+```
+
+詳細パターンは `references/bounded-contexts-and-aggregates.md` を参照。
+
+## ddd-design ドキュメント索引
+
+- [2.00: ドメインモデル全体図](docs/project/ddd-design/2.00_domain-model-overview.md) — Mermaid 図・集約設計・実装指針
+- [2.02: ドメイン理解](docs/project/ddd-design/2.02_domain-understanding/)
+- [2.03: ユビキタス言語辞書](docs/project/ddd-design/2.03_ubiquitous-language/)
+- [2.04: イベントストーミング](docs/project/ddd-design/2.04_event-storming/)
+- [2.05: ドメインオブジェクト抽出](docs/project/ddd-design/2.05_domain-object-extraction/)
+- [2.08: 集約設計](docs/project/ddd-design/2.08_aggregate-design/) — 各集約の詳細設計
+- [2.09: 境界コンテキスト定義](docs/project/ddd-design/2.09_bounded-context-definition/)
+- [2.10: ドメインイベントカタログ](docs/project/ddd-design/2.10_domain-events-catalog/)
+- [2.11: オントロジー](docs/project/ddd-design/2.11_ontology-creation/)
+
+## 出力形式
+
+- TypeScript コード（Brand 型 / AggregateRoot / Result 型パターン）
+- ドメインイベント定義（`DomainEvent` インターフェース準拠）
+- 集約の責務・不変条件の説明（ユビキタス言語使用）
+
+## ガードレール
+
+- `docs/project/ddd-design/**` は変更しない（source of truth）
+- ユビキタス言語辞書の用語を必ず使用する（独自用語の追加は辞書を先に更新）
+- コンテキスト間の依存方向（上流→下流）を守る
+- 集約境界を越えた直接参照を避ける（ID 参照のみ）
+- 汎用 DDD method（戦略/戦術設計の手順）は `ddd-modeling` skill を参照する
+
+## 評価シナリオ
+
+1. 「クイズ集約を実装したい」→ Quiz Management Context → 2.08_aggregate-design を参照
+2. 「学習セッションのドメインイベントは？」→ 2.10_domain-events-catalog を参照
+3. 「ユビキタス言語で "Deck" は何？」→ 2.03_ubiquitous-language を参照
+4. 「DDD の戦略設計の手順を教えて」→ `ddd-modeling` skill（汎用 method 層）を呼ぶ
+5. 「境界コンテキストの依存方向を確認したい」→ 2.09_bounded-context-definition と references/bounded-contexts-and-aggregates.md を参照
+
+## 関連リファレンス
+
+- [references/bounded-contexts-and-aggregates.md](references/bounded-contexts-and-aggregates.md) — コンテキスト・集約の詳細と TypeScript パターン
+- [references/ubiquitous-language-quickref.md](references/ubiquitous-language-quickref.md) — 主要用語クイックリファレンス
+- 関連 skill（汎用 method 層）: `ddd-modeling`
+- 関連 skill（project 事実層）: `your-quiz-api`（ドメイン → API の橋渡し）, `your-quiz-project-knowledge`（全体索引）

--- a/.apm/skills/your-quiz-domain/SKILL.md
+++ b/.apm/skills/your-quiz-domain/SKILL.md
@@ -46,24 +46,28 @@ compatibility: Requires access to docs/project/ddd-design/ in this repository.
 ## 主要集約 サマリー
 
 ### Quiz Aggregate（権威的）
+
 - **責務**: クイズ内容の品質保証・承認フロー・ライフサイクル管理
 - **状態遷移**: 投稿 → 承認 → 公開（強一貫性）
 - **設計決定**: 単一エンティティ集約（クイズ≠回答の分離）
 - 詳細 → `docs/project/ddd-design/2.08_aggregate-design/`
 
 ### Learning Session Aggregate（中核）
+
 - **責務**: 学習体験・回答履歴・学習進捗計算
 - **設計決定**: 複合集約（Session + Answer の一体管理）、結果整合性
 - **パフォーマンス**: 高頻度アクセス、CQRS 的クエリ分離
 - 詳細 → `docs/project/ddd-design/2.08_aggregate-design/`
 
 ### User Session Aggregate（支援的）
+
 - **責務**: 匿名ユーザー識別・セッション管理・作成者権限制御
 - **設計決定**: 軽量集約、プライバシー重視（個人情報なし）
 - **VO**: `DeviceFingerprint`, `CreatorId`
 - 詳細 → `docs/project/ddd-design/2.08_aggregate-design/`
 
 ### Sync Session Aggregate（技術的）
+
 - **責務**: オフライン/オンライン同期・データ競合解決・整合性保証
 - **設計決定**: 技術集約、横断的関心事（全データが同期対象）
 - 詳細 → `docs/project/ddd-design/2.08_aggregate-design/`

--- a/.apm/skills/your-quiz-domain/references/bounded-contexts-and-aggregates.md
+++ b/.apm/skills/your-quiz-domain/references/bounded-contexts-and-aggregates.md
@@ -4,7 +4,7 @@
 
 ## コンテキストマップ
 
-```
+```text
 [Quiz Management] ──Published Language──→ [Quiz Learning]
 [User Session]    ──Customer/Supplier──→  [Quiz Learning]
 [Quiz Learning]   ──Customer/Supplier──→  [Offline Sync]
@@ -128,7 +128,7 @@ class InvariantViolationError extends DomainError {
 
 ## ディレクトリ構造（実装時の指針）
 
-```
+```text
 src/
 ├── contexts/
 │   ├── quiz-management/

--- a/.apm/skills/your-quiz-domain/references/bounded-contexts-and-aggregates.md
+++ b/.apm/skills/your-quiz-domain/references/bounded-contexts-and-aggregates.md
@@ -1,0 +1,154 @@
+# 境界づけられたコンテキストと集約の詳細
+
+詳細な設計成果物は `docs/project/ddd-design/` を参照すること。本ファイルは実装時の参照用概要。
+
+## コンテキストマップ
+
+```
+[Quiz Management] ──Published Language──→ [Quiz Learning]
+[User Session]    ──Customer/Supplier──→  [Quiz Learning]
+[Quiz Learning]   ──Customer/Supplier──→  [Offline Sync]
+[Quiz Management] ──Anti-Corruption──→   [Offline Sync]
+[User Session]    ──Conformist──────────→ [Offline Sync]
+```
+
+## 集約別 TypeScript 実装要点
+
+### Quiz Aggregate
+
+```typescript
+class QuizAggregate extends AggregateRoot<QuizId> {
+  // 状態: Draft → PendingApproval → Approved → Published
+  private status: QuizStatus;
+
+  static create(cmd: CreateQuizCommand): Result<QuizAggregate, ValidationError> {
+    // 不変条件: 質問テキスト ≤ 500文字、正解が存在する
+    const question = Question.create(cmd.questionText);
+    if (question.isErr()) return err(question.error);
+    // ...
+  }
+
+  approve(administratorId: AdministratorId): Result<void, BusinessRuleError> {
+    if (this.status !== QuizStatus.PendingApproval)
+      return err(new BusinessRuleError("承認待ち状態でのみ承認可能"));
+    this.status = QuizStatus.Approved;
+    this.addDomainEvent(new QuizApproved(this.id, administratorId));
+    return ok(undefined);
+  }
+}
+```
+
+### Learning Session Aggregate
+
+```typescript
+class LearningSessionAggregate extends AggregateRoot<SessionId> {
+  private answers: Answer[] = [];
+  private progress: LearningProgress;
+
+  answerQuiz(quizId: QuizId, isCorrect: boolean, answered: boolean): Result<void, BusinessRuleError> {
+    // 不変条件: 同一クイズへの重複回答を防ぐ
+    if (this.answers.some(a => a.quizId.equals(quizId)))
+      return err(new BusinessRuleError("既に回答済み"));
+    this.answers.push(Answer.create(quizId, isCorrect));
+    this.progress = this.calculateProgress();
+    return ok(undefined);
+  }
+
+  getProgress(): LearningProgress { return this.progress; }
+}
+```
+
+### User Session Aggregate
+
+```typescript
+class UserSessionAggregate extends AggregateRoot<UserId> {
+  // 個人情報なし: DeviceFingerprint で匿名識別
+  private constructor(
+    readonly id: UserId,
+    readonly deviceFingerprint: DeviceFingerprint,
+    readonly creatorId: CreatorId,
+  ) { super(); }
+
+  static create(device: DeviceFingerprint): Result<UserSessionAggregate, ValidationError> {
+    const userId = UserId.generate();
+    const creatorId = CreatorId.fromUserId(userId);
+    return ok(new UserSessionAggregate(userId, device, creatorId));
+  }
+}
+```
+
+## 共通基盤（Shared Kernel）
+
+```typescript
+// Brand 型（識別子の型安全性）
+declare const brand: unique symbol;
+type Brand<T, B> = T & { readonly [brand]: B };
+
+type QuizId = Brand<string, 'QuizId'>;
+type SessionId = Brand<string, 'SessionId'>;
+type AnswerId = Brand<string, 'AnswerId'>;
+type UserId = Brand<string, 'UserId'>;
+
+// DomainEvent 基底
+interface DomainEvent {
+  readonly eventId: string;
+  readonly eventType: string;
+  readonly aggregateId: string;
+  readonly occurredAt: Date;
+}
+
+// AggregateRoot 基底
+abstract class AggregateRoot<TId> {
+  private readonly _domainEvents: DomainEvent[] = [];
+  protected addDomainEvent(event: DomainEvent): void {
+    this._domainEvents.push(event);
+  }
+  getDomainEvents(): readonly DomainEvent[] { return [...this._domainEvents]; }
+  clearDomainEvents(): void { this._domainEvents.length = 0; }
+}
+
+// DomainError 分類
+abstract class DomainError extends Error {
+  abstract readonly errorCode: string;
+  abstract readonly severity: 'warning' | 'error' | 'critical';
+}
+class ValidationError extends DomainError {
+  readonly errorCode = 'VALIDATION_ERROR';
+  readonly severity = 'warning' as const;
+}
+class BusinessRuleError extends DomainError {
+  readonly errorCode = 'BUSINESS_RULE_VIOLATION';
+  readonly severity = 'error' as const;
+}
+class InvariantViolationError extends DomainError {
+  readonly errorCode = 'INVARIANT_VIOLATION';
+  readonly severity = 'critical' as const;
+}
+```
+
+## ディレクトリ構造（実装時の指針）
+
+```
+src/
+├── contexts/
+│   ├── quiz-management/
+│   │   ├── domain/
+│   │   │   ├── entities/          # Quiz エンティティ
+│   │   │   ├── value-objects/     # Question, QuizStatus, Tag VO
+│   │   │   ├── aggregates/        # QuizAggregate
+│   │   │   ├── repositories/      # QuizRepository インターフェース
+│   │   │   └── services/          # ドメインサービス
+│   │   ├── application/
+│   │   │   ├── commands/
+│   │   │   ├── queries/
+│   │   │   └── services/
+│   │   └── infrastructure/
+│   ├── quiz-learning/             # 同様の構造
+│   ├── user-session/              # 同様の構造
+│   └── offline-sync/              # 同様の構造
+└── shared-kernel/
+    ├── types/                     # Brand 型定義
+    ├── value-objects/             # 共通 VO
+    ├── domain-events/             # DomainEvent 基底
+    └── utilities/
+```

--- a/.apm/skills/your-quiz-domain/references/ubiquitous-language-quickref.md
+++ b/.apm/skills/your-quiz-domain/references/ubiquitous-language-quickref.md
@@ -41,17 +41,21 @@
 ## コンテキスト別の主要用語
 
 ### Quiz Management Context
+
 `Quiz`, `Question`, `Solution`, `Explanation`, `Tag`, `Creator`, `Administrator`,
 `Draft`, `PendingApproval`, `Approved`, `Rejected`
 
 ### Quiz Learning Context
+
 `Deck`, `QuizSession`, `Attempt`, `AttemptHistory`, `CorrectJudgment`, `Filter`,
 `SwipeGesture`, `SaveSearchResults`
 
 ### User Session Context
+
 `AnonymousUser`, `Creator`, `CreatorIdentification`, `DeviceFingerprint`
 
 ### Offline Sync Context
+
 `OfflineMode`, `Synchronization`, `SyncItem`, `ConflictResolution`
 
 ## 制約・不変条件

--- a/.apm/skills/your-quiz-domain/references/ubiquitous-language-quickref.md
+++ b/.apm/skills/your-quiz-domain/references/ubiquitous-language-quickref.md
@@ -1,0 +1,62 @@
+# ユビキタス言語クイックリファレンス
+
+完全版は `docs/project/ddd-design/2.03_ubiquitous-language/ubiquitous-language-dictionary.md` を参照すること。
+
+## Core 用語（実装で必ず使う語）
+
+| 日本語 | 英語/TypeScript名 | 定義 |
+|--------|------------------|------|
+| クイズ | `Quiz` | ○×形式の問題と正解・解説で構成される学習単位 |
+| 問題文 | `Question` | ユーザーが判断する対象テキスト（≤ 500文字）|
+| 正解 | `Solution` | ○または×の二択による問題の答え |
+| 解説 | `Explanation` | 答えの詳細説明（≤ 1000文字・任意）|
+| タグ | `Tag` | クイズの分類・検索ラベル（複数設定可）|
+| 回答試行 | `Attempt` | ユーザーが行った○または×の選択 |
+| 回答履歴 | `AttemptHistory` | 過去の回答記録（ブラウザ保存）|
+| 問題集 | `Deck` | 検索結果や選択クイズの集合（学習単位）|
+| セッション | `QuizSession` | Deck に対する学習セッション（Deck と 1:1）|
+| 匿名ユーザー | `AnonymousUser` | ログイン不要でアプリを利用するユーザー |
+| 作成者 | `Creator` | クイズを投稿したユーザー（salt 付きハッシュで識別）|
+| 管理者 | `Administrator` | クイズの承認・管理権限を持つユーザー |
+
+## Quiz ライフサイクル（状態）
+
+| 状態 | 英語名 | 説明 |
+|------|--------|------|
+| 下書き | `Draft` | 作成中・未投稿 |
+| 承認待ち | `PendingApproval` | 投稿済み・管理者承認待ち |
+| 承認済み | `Approved` | 管理者承認・公開中 |
+| 承認拒否 | `Rejected` | 管理者による拒否 |
+
+## 操作・ドメインイベント
+
+| 日本語 | 英語/イベント名 | 説明 |
+|--------|---------------|------|
+| 投稿 | `Submit` / `QuizSubmitted` | クイズをシステムに送信 |
+| 承認 | `Approve` / `QuizApproved` | 管理者による承認 |
+| 拒否 | `Reject` / `QuizRejected` | 管理者による拒否 |
+| 問題集作成 | `CreateDeck` / `DeckCreated` | 検索結果等から Deck を作成 |
+| 同期処理 | `Synchronization` / `SyncCompleted` | オフライン→オンライン同期 |
+
+## コンテキスト別の主要用語
+
+### Quiz Management Context
+`Quiz`, `Question`, `Solution`, `Explanation`, `Tag`, `Creator`, `Administrator`,
+`Draft`, `PendingApproval`, `Approved`, `Rejected`
+
+### Quiz Learning Context
+`Deck`, `QuizSession`, `Attempt`, `AttemptHistory`, `CorrectJudgment`, `Filter`,
+`SwipeGesture`, `SaveSearchResults`
+
+### User Session Context
+`AnonymousUser`, `Creator`, `CreatorIdentification`, `DeviceFingerprint`
+
+### Offline Sync Context
+`OfflineMode`, `Synchronization`, `SyncItem`, `ConflictResolution`
+
+## 制約・不変条件
+
+- `Question`: テキスト ≤ 500文字
+- `Explanation`: テキスト ≤ 1000文字（任意）
+- `DuplicateSubmission`: 同一ユーザーによる同一問題の複数回投稿は**許可**
+- `CharacterLimit`: 入力時にバリデーション + Sanitize（XSS 対策）

--- a/.apm/skills/your-quiz-project-knowledge/SKILL.md
+++ b/.apm/skills/your-quiz-project-knowledge/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: your-quiz-project-knowledge
+description: Provides cross-cutting project knowledge for Your Quiz — a quiz creation and learning app with anonymous users. Activate when you need overall project context: product overview, ADR decisions, system architecture (modular monolith + hexagonal), NFR targets, tech stack summary, or when navigating between domain/API/UI areas. Reference index pointing to docs/project/** source-of-truth artifacts.
+license: MIT
+metadata:
+  author: personal
+  version: "0.1.0"
+compatibility: Requires access to docs/project/** in this repository.
+---
+
+# Your Quiz プロジェクト知識（横断索引）
+
+## 利用タイミング
+
+- プロジェクト全体の概要・背景を把握したいとき
+- ADR（アーキテクチャ決定記録）を参照したいとき
+- システムアーキテクチャ・NFR・技術スタックを確認したいとき
+- ドメイン / API / UI の全体マップが必要なとき
+- 仕様書・UI 設計・テスト・toolchain のドキュメントを探すとき
+
+## 確認する入力
+
+- 目的（設計確認 / 実装参照 / 仕様理解 / ADR 参照）
+- 関心領域（architecture / domain / api / ui / spec / test / toolchain）
+
+## Workflow
+
+1. 関心領域を特定する
+2. 下記の索引から該当 `docs/project/**` ファイルへ直接アクセスする
+3. ドメイン実装には `your-quiz-domain` skill、API 実装には `your-quiz-api` skill を呼び出す
+4. skill 内の `references/` を補足として参照する
+
+## プロダクト概要
+
+- **アプリ**: Your Quiz — ○×クイズを作成・共有・回答するWebアプリ
+- **ユーザー**: 匿名（JWT + デバイス識別）、クイズ作成者と学習者の両役割
+- [要件定義](docs/project/specifications/requirements/)
+- [ユーザーストーリー](docs/project/specifications/user-stories/)
+
+## アーキテクチャ索引
+
+- **パターン**: モジュラーモノリス + ヘキサゴナルアーキテクチャ（Ports & Adapters）
+- [システム全体俯瞰](docs/project/architecture/system-overview.md)
+- [技術選定](docs/project/architecture/tech-selection.md)
+- [通信パターン](docs/project/architecture/communication-patterns.md)
+- [データアーキテクチャ](docs/project/architecture/data-architecture.md)
+- [NFR（非機能要件）](docs/project/architecture/non-functional-requirements.md): API 応答 ≤ 100ms (95%ile)、検索 ≤ 200ms、同時接続 1000、アップタイム 99.9%
+
+## ADR 索引
+
+- [ADR 一覧](docs/project/adr/) — 25件
+- 主要決定: モジュラーモノリス(0001)、ヘキサゴナル(0002)、Next.js(0003)、Hono(0006)、SQLite+D1(0007)、Zod(0010)、Vercel(0013)、Cloudflare Workers(0014)
+
+## 技術スタック サマリー
+
+| 領域 | 採用技術 |
+|------|---------|
+| Frontend | Next.js 15 (App Router), Tailwind CSS, Jotai |
+| Backend | Hono `^4.8.10`, TypeSpec, neverthrow `^8.2.0`, Zod `^4.0.14` |
+| DB | SQLite + Cloudflare D1, Drizzle ORM |
+| Infra | Vercel（UI）, Cloudflare Workers（API）|
+| Test | Vitest, Playwright |
+
+## ドメイン / API / UI マップ
+
+| 領域 | 参照先 | ドキュメント |
+|------|--------|------------|
+| DDD モデル・境界・集約 | skill: `your-quiz-domain` | [docs/project/ddd-design/](docs/project/ddd-design/) |
+| API catalog・実装ルール | skill: `your-quiz-api` | [docs/project/api-design/](docs/project/api-design/) |
+| UI 設計・フロー | — | [docs/project/ui-design/](docs/project/ui-design/) |
+| 仕様書 | — | [docs/project/specifications/](docs/project/specifications/) |
+
+## toolchain / test ドキュメント
+
+- [pnpm スクリプト一覧](docs/instructions/project/pnpm-scripts.md): `test`, `test:unit`, `test:bdd`, `test:e2e`, `build`, `lint`, `typecheck`
+- [UI 設計](docs/project/ui-design/): サイトマップ、ユーザーフロー、ワイヤーフレーム、コンポーネント
+
+## 出力形式
+
+- 索引から該当ドキュメントへのパスを返す
+- 必要に応じて `your-quiz-domain` / `your-quiz-api` skill へ誘導する
+
+## ガードレール
+
+- `docs/project/**` ファイルは変更しない（source of truth）
+- ドメイン実装の詳細は `your-quiz-domain`、API 実装の詳細は `your-quiz-api` で扱う
+- 汎用 method（手順・設計パターン）は対応する tanacchi/skills skill を参照する
+
+## 評価シナリオ
+
+1. 「プロジェクトの技術スタックを教えて」→ 技術スタック サマリー を返し、詳細は tech-selection.md へ
+2. 「ADR を確認したい」→ docs/project/adr/ へ誘導
+3. 「API の設計・実装については？」→ `your-quiz-api` skill へ誘導
+4. 「ドメインモデルの境界は？」→ `your-quiz-domain` skill へ誘導
+
+## 関連リファレンス
+
+- [references/project-index.md](references/project-index.md) — ドキュメント体系の全体説明
+- 関連 skill（汎用 method 層）: `spec-authoring`, `architecture-method`, `workflow-orchestration`
+- 関連 skill（project 事実層）: `your-quiz-api`, `your-quiz-domain`

--- a/.apm/skills/your-quiz-project-knowledge/references/project-index.md
+++ b/.apm/skills/your-quiz-project-knowledge/references/project-index.md
@@ -1,0 +1,73 @@
+# Your Quiz ドキュメント体系
+
+## docs/project/** — source of truth
+
+```
+docs/project/
+├── adr/                        # ADR（アーキテクチャ決定記録）25件
+│   ├── 0001-architecture-pattern.md
+│   ├── 0002-application-architecture.md
+│   └── ... (0003〜0025)
+├── api-design/                 # API 設計（→ your-quiz-api skill）
+│   ├── README.md               # API 全体概要・主要フロー
+│   ├── api-catalog/            # エンドポイント一覧（8ファイル）
+│   ├── design-principles.md    # 設計原則
+│   ├── non-functional-requirements.md
+│   ├── implementation-migration-plan.md
+│   ├── pub-sub-integration.md
+│   └── sdk-generation-strategy.md
+├── architecture/               # システムアーキテクチャ
+│   ├── system-overview.md      # システム全体俯瞰・モジュール構成
+│   ├── tech-selection.md       # 技術選定結果まとめ
+│   ├── communication-patterns.md
+│   ├── data-architecture.md
+│   ├── non-functional-requirements.md
+│   └── diagrams/               # 構成図（Mermaid等）
+├── ddd-design/                 # DDD 設計（→ your-quiz-domain skill）
+│   ├── 2.00_domain-model-overview.md  # ドメインモデル全体図・実装指針
+│   ├── 2.02_domain-understanding/
+│   ├── 2.02_user-flow-analysis/
+│   ├── 2.03_ubiquitous-language/      # ユビキタス言語辞書
+│   ├── 2.04_event-storming/
+│   ├── 2.05_domain-object-extraction/
+│   ├── 2.06_entity-relationship-analysis/
+│   ├── 2.07_domain-service-extraction/
+│   ├── 2.08_aggregate-design/         # 各集約の詳細設計
+│   ├── 2.09_bounded-context-definition/
+│   ├── 2.10_domain-events-catalog/    # ドメインイベント一覧
+│   └── 2.11_ontology-creation/
+├── specifications/             # 仕様書
+│   ├── requirements/           # 機能要件
+│   ├── user-stories/           # ユーザーストーリー
+│   ├── success-scenarios/      # 成功シナリオ
+│   ├── error-scenarios/        # エラーシナリオ
+│   └── future-work.md
+└── ui-design/                  # UI 設計
+    ├── 1.00_overview.md
+    ├── 1.01_sitemap.yaml       # 全画面一覧
+    ├── 1.02_user-stories/
+    ├── 2.01_user-flows/
+    ├── 3.01_wireframes/
+    ├── 4.01_components/
+    └── 5.01_integration/
+```
+
+## docs/instructions/project/ — 実装ルール（your-quiz-api skill が吸収）
+
+```
+docs/instructions/project/
+├── api-implementation-rules.md   # 実装必須ルール（neverthrow/Zod パターン）
+├── api-implementation-samples.md # 実装サンプルコード
+├── api-libraries-guide.md        # ライブラリ使用ガイド（Hono/neverthrow/Zod）
+├── pnpm-scripts.md               # pnpm スクリプト一覧
+└── README.md                     # 索引
+```
+
+## .apm/skills/ — project skill 層（このリポジトリ）
+
+```
+.apm/skills/
+├── your-quiz-project-knowledge/  # 横断索引（本 skill）
+├── your-quiz-api/                # API catalog・実装ルール
+└── your-quiz-domain/             # DDD モデル・境界・集約
+```

--- a/.apm/skills/your-quiz-project-knowledge/references/project-index.md
+++ b/.apm/skills/your-quiz-project-knowledge/references/project-index.md
@@ -2,7 +2,7 @@
 
 ## docs/project/** — source of truth
 
-```
+```text
 docs/project/
 ├── adr/                        # ADR（アーキテクチャ決定記録）25件
 │   ├── 0001-architecture-pattern.md
@@ -54,7 +54,7 @@ docs/project/
 
 ## docs/instructions/project/ — 実装ルール（your-quiz-api skill が吸収）
 
-```
+```text
 docs/instructions/project/
 ├── api-implementation-rules.md   # 実装必須ルール（neverthrow/Zod パターン）
 ├── api-implementation-samples.md # 実装サンプルコード
@@ -65,7 +65,7 @@ docs/instructions/project/
 
 ## .apm/skills/ — project skill 層（このリポジトリ）
 
-```
+```text
 .apm/skills/
 ├── your-quiz-project-knowledge/  # 横断索引（本 skill）
 ├── your-quiz-api/                # API catalog・実装ルール

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -4,7 +4,8 @@
     "**/tmp/**",
     "**/dist/**",
     "./.serena/**",
-    "**/mutation-analysis/**"
+    "**/mutation-analysis/**",
+    "./skills/**"
   ],
   "config": {
     "default": true,

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -eu
+
+failures=0
+
+fail() {
+  printf "fail: %s\n" "$1" >&2
+  failures=$((failures + 1))
+}
+
+# machine-specific absolute path check
+if command -v rg >/dev/null 2>&1; then
+  if rg -n '(/[U]sers/|/[h]ome/)' .apm/skills --hidden -g '!/.git/**' >/tmp/yq-skills-paths.$$; then
+    while IFS= read -r match; do
+      fail "machine-specific absolute path found: $match"
+    done </tmp/yq-skills-paths.$$
+  fi
+  rm -f /tmp/yq-skills-paths.$$
+else
+  printf "info: rg not installed; skipping machine-specific path check\n"
+fi
+
+# skills symlink check
+if [ ! -L "skills" ]; then
+  fail "skills must be a symlink to .apm/skills"
+else
+  skills_target=$(readlink "skills")
+  [ "$skills_target" = ".apm/skills" ] || fail "skills symlink points to '$skills_target', expected '.apm/skills'"
+fi
+
+# per-skill validation
+for skill_dir in .apm/skills/*; do
+  [ -d "$skill_dir" ] || continue
+  skill_name=$(basename "$skill_dir")
+  skill_file="$skill_dir/SKILL.md"
+
+  if [ ! -f "$skill_file" ]; then
+    fail "missing SKILL.md: $skill_dir"
+    continue
+  fi
+
+  first_line=$(sed -n '1p' "$skill_file")
+  [ "$first_line" = "---" ] || fail "$skill_file must start with YAML frontmatter"
+
+  declared_name=$(sed -n 's/^name: *//p' "$skill_file" | head -n 1)
+  description=$(sed -n 's/^description: *//p' "$skill_file" | head -n 1)
+
+  [ -n "$declared_name" ] || fail "$skill_file missing name"
+  [ -n "$description" ] || fail "$skill_file missing description"
+  [ "$declared_name" = "$skill_name" ] || fail "$skill_file name '$declared_name' does not match directory '$skill_name'"
+done
+
+if [ "$failures" -gt 0 ]; then
+  printf "validation failed: %s issue(s)\n" "$failures" >&2
+  exit 1
+fi
+
+printf "validation passed\n"

--- a/skills
+++ b/skills
@@ -1,0 +1,1 @@
+.apm/skills


### PR DESCRIPTION
## Summary

プロンプト資産 skills 化の **Phase B**。your-quiz リポジトリに `.apm` を構築し、プロジェクト固有の知識を Claude Code skill として配置する。

### 変更内容

- **`.apm/skills/`** に project-scoped skill 3本を新設（汎用 method 層 `tanacchi/skills` と2層で補完）
  - `your-quiz-project-knowledge` — 横断索引 skill（ADR / architecture / NFR / domain↔API↔UI マップ / docs ポインタ）
  - `your-quiz-api` — API catalog（8コンテキスト）+ Hono/neverthrow/Zod/Cloudflare 実装ルール（高頻度発火）
  - `your-quiz-domain` — DDD モデル・4境界コンテキスト・集約・ユビキタス言語・ドメインイベント（高頻度発火）
- **`scripts/validate.sh`** — frontmatter・name-dir 一致・machine-specific path を検証
- **`skills -> .apm/skills`** — skill loader 向け symlink

### 設計方針（2層モデル）

| 層 | リポジトリ | 内容 |
|---|---|---|
| 汎用 method 層 | `tanacchi/skills` | やり方（spec/arch/ddd/api/impl/test/toolchain 手順） |
| project 事実層 | `your-quiz`（本 PR）| Your Quiz 固有事実（docs/project/** を参照） |

- `your-quiz-*` prefix で汎用 skill との name 衝突を回避
- `docs/project/**` は source of truth として現状維持（skill が参照する側）
- machine-specific path なし（validate.sh 確認済み）

### 関連 PR / Context

- Phase A（tanacchi/skills 側）: https://github.com/tanacchi/skills/pull/15
- Phase C（workflow orchestrator）・Phase D（レガシー撤去）は次 PR

## Test plan

- [ ] `sh scripts/validate.sh` がパスすることを確認（`validation passed`）
- [ ] `skills` symlink が `.apm/skills` を指すことを確認（`ls -la skills`）
- [ ] 各 SKILL.md の frontmatter に `name` と `description` が揃っていることを確認
- [ ] machine-specific path（`/Users/`・`/home/`）が含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)