### PR TITLE
api: TypeSpec 整合＆再有効化（learning/user-session 有効化・PATCH統一）

### DIFF
--- a/api/spec/main.tsp
+++ b/api/spec/main.tsp
@@ -8,8 +8,8 @@ import "./models/attempt.tsp";
 import "./models/deck.tsp";
 import "./models/tag.tsp";
 import "./operations/quiz-management.tsp";
-// import "./operations/quiz-learning.tsp";
-// import "./operations/user-session.tsp";
+import "./operations/quiz-learning.tsp";
+import "./operations/user-session.tsp";
 import "./operations/search.tsp";
 
 using Http;

--- a/api/spec/models/attempt.tsp
+++ b/api/spec/models/attempt.tsp
@@ -54,8 +54,10 @@ model AttemptWithAnswer {
 }
 
 // Request/Response models
+// Note: sessionId is intentionally omitted — it is already carried by the
+// @path parameter on submitAnswer, and duplicating it in the body would
+// leave the sessionId vs. path-id consistency undefined on mismatch.
 model SubmitAnswerRequest {
-  sessionId: SessionId;
   quizId: QuizId;
   answer: Answer;
 }

--- a/api/spec/operations/quiz-learning.tsp
+++ b/api/spec/operations/quiz-learning.tsp
@@ -108,7 +108,7 @@ interface QuizLearning {
   // Answer Submission
 
   /** Submit answer to quiz in session */
-  @put
+  @post
   @route("/sessions/{sessionId}/answers")
   submitAnswer(@path sessionId: SessionId, @body request: SubmitAnswerRequest): SubmitAnswerResponse | ValidationError | NotFoundError | ConflictError;
 

--- a/api/spec/operations/quiz-learning.tsp
+++ b/api/spec/operations/quiz-learning.tsp
@@ -87,7 +87,7 @@ interface QuizLearning {
   getSession(@path id: SessionId): QuizSessionWithProgress | NotFoundError;
 
   /** Update session (mark completed, etc.) */
-  @patch
+  @patch(#{ implicitOptionality: false })
   @route("/sessions/{id}")
   updateSession(@path id: SessionId, @body request: UpdateSessionRequest): QuizSessionWithProgress | NotFoundError | ValidationError;
 
@@ -107,10 +107,13 @@ interface QuizLearning {
 
   // Answer Submission
 
-  /** Submit answer to quiz in session */
+  /** Submit answer to quiz in session (creates a new Attempt) */
   @post
-  @route("/sessions/{sessionId}/answers")
-  submitAnswer(@path sessionId: SessionId, @body request: SubmitAnswerRequest): SubmitAnswerResponse | ValidationError | NotFoundError | ConflictError;
+  @route("/sessions/{id}/answers")
+  submitAnswer(@path id: SessionId, @body request: SubmitAnswerRequest): {
+    @statusCode statusCode: 201;
+    ...SubmitAnswerResponse;
+  } | ValidationError | NotFoundError | ConflictError;
 
   /** Get answer history for session */
   @get
@@ -119,8 +122,8 @@ interface QuizLearning {
 
   /** Check if quiz is already answered in session */
   @get
-  @route("/sessions/{sessionId}/answers/{quizId}")
-  getSessionAnswer(@path sessionId: SessionId, @path quizId: QuizId): AttemptWithAnswer | NotFoundError;
+  @route("/sessions/{id}/answers/{quizId}")
+  getSessionAnswer(@path id: SessionId, @path quizId: QuizId): AttemptWithAnswer | NotFoundError;
 
   // Learning Statistics
 

--- a/api/spec/operations/quiz-learning.tsp
+++ b/api/spec/operations/quiz-learning.tsp
@@ -87,7 +87,7 @@ interface QuizLearning {
   getSession(@path id: SessionId): QuizSessionWithProgress | NotFoundError;
 
   /** Update session (mark completed, etc.) */
-  @put
+  @patch
   @route("/sessions/{id}")
   updateSession(@path id: SessionId, @body request: UpdateSessionRequest): QuizSessionWithProgress | NotFoundError | ValidationError;
 

--- a/api/spec/operations/quiz-management.tsp
+++ b/api/spec/operations/quiz-management.tsp
@@ -168,7 +168,7 @@ interface QuizManagement {
     - **管理業務**: 作成者変更や大幅な内容修正
     - **品質向上**: 解説の充実化やタグ分類の見直し
     """)
-  @patch
+  @patch(#{ implicitOptionality: false })
   @route("/quizzes/{id}")
   updateQuiz(
     @doc("更新対象のクイズID（UUID形式）")

--- a/api/spec/operations/user-session.tsp
+++ b/api/spec/operations/user-session.tsp
@@ -59,7 +59,7 @@ interface UserSession {
   getUserAccount(@path id: UserAccountId): UserAccount | NotFoundError;
   
   /** Update user account */
-  @put
+  @patch
   @route("/accounts/{id}")
   updateUserAccount(@path id: UserAccountId, @body request: UpdateUserAccountRequest): UserAccount | NotFoundError | ValidationError;
   

--- a/api/spec/operations/user-session.tsp
+++ b/api/spec/operations/user-session.tsp
@@ -59,7 +59,7 @@ interface UserSession {
   getUserAccount(@path id: UserAccountId): UserAccount | NotFoundError;
   
   /** Update user account */
-  @patch
+  @patch(#{ implicitOptionality: false })
   @route("/accounts/{id}")
   updateUserAccount(@path id: UserAccountId, @body request: UpdateUserAccountRequest): UserAccount | NotFoundError | ValidationError;
   

--- a/api/spec/tests/openapi-contract.test.ts
+++ b/api/spec/tests/openapi-contract.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @file openapi-contract.test.ts
+ * @description TypeSpecからコンパイルされたOpenAPIドキュメントの契約検証。
+ *
+ * `tsp compile` はパステンプレートのパラメータ名違い（例: `/sessions/{id}/answers`
+ * と `/sessions/{sessionId}/answers`）を検出せず、OpenAPI 3.1が禁止する
+ * 「同一階層で異なるテンプレート名を持つパス」を素通りさせてしまう
+ * （PR #61 レビューで発覚した実際のリグレッション）。
+ * このテストはコンパイル結果に対して直接そのクラスの不整合を検出する。
+ */
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const specRoot = path.resolve(__dirname, "..");
+
+type OpenApiOperation = {
+  responses: Record<string, unknown>;
+};
+
+type OpenApiPathItem = Partial<
+  Record<"get" | "post" | "put" | "patch" | "delete", OpenApiOperation>
+>;
+
+type OpenApiDocument = {
+  paths: Record<string, OpenApiPathItem>;
+};
+
+let openApiDoc: OpenApiDocument;
+let outDir: string;
+
+beforeAll(() => {
+  outDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsp-contract-test-"));
+  const outputFile = "contract.json";
+
+  // 生成物(generated/api.yaml)はgitignore対象でbuild実行順序に依存するため、
+  // テスト自身がJSON形式で独立にコンパイルし、生成結果を直接検証する。
+  execFileSync(
+    "tsp",
+    [
+      "compile",
+      ".",
+      "--option",
+      "@typespec/openapi3.file-type=json",
+      "--option",
+      `@typespec/openapi3.output-file=${outputFile}`,
+      "--option",
+      `@typespec/openapi3.emitter-output-dir=${outDir}`,
+    ],
+    { cwd: specRoot, stdio: "pipe" },
+  );
+
+  const raw = fs.readFileSync(path.join(outDir, outputFile), "utf-8");
+  openApiDoc = JSON.parse(raw);
+});
+
+afterAll(() => {
+  fs.rmSync(outDir, { recursive: true, force: true });
+});
+
+/**
+ * `/a/{foo}/b` と `/a/{bar}/b` のように、テンプレート変数名だけが異なる
+ * 同一階層のパスを正規化して比較できる形にする。
+ */
+function normalizePathTemplate(pathTemplate: string): string {
+  return pathTemplate.replace(/\{[^}]+\}/g, "{}");
+}
+
+describe("OpenAPI契約", () => {
+  it("同一階層で異なるテンプレート名を持つパスが存在しない", () => {
+    const paths = Object.keys(openApiDoc.paths);
+    const byNormalized = new Map<string, string[]>();
+
+    for (const p of paths) {
+      const normalized = normalizePathTemplate(p);
+      const bucket = byNormalized.get(normalized) ?? [];
+      bucket.push(p);
+      byNormalized.set(normalized, bucket);
+    }
+
+    const collisions = [...byNormalized.entries()].filter(
+      ([, variants]) => variants.length > 1,
+    );
+
+    expect(
+      collisions,
+      `OpenAPI 3.1は同一階層で異なるテンプレート名を持つパスを禁止している。検出された衝突: ${JSON.stringify(collisions)}`,
+    ).toEqual([]);
+  });
+
+  it("submitAnswer (POST /sessions/{id}/answers) は201 Createdを返す", () => {
+    const answersPath =
+      openApiDoc.paths["/api/quiz/v1/learning/sessions/{id}/answers"];
+    expect(answersPath, "セッション回答パスが存在すること").toBeDefined();
+
+    const post = answersPath?.post;
+    expect(post, "answersパスにPOST操作が定義されていること").toBeDefined();
+    if (!post) return;
+
+    expect(
+      Object.keys(post.responses),
+      "submitAnswerは新規Attempt作成のため201を返すこと",
+    ).toContain("201");
+  });
+
+  it("同一URLに対してGETとPOSTが1つのpath itemとして統合されている", () => {
+    const answersPath =
+      openApiDoc.paths["/api/quiz/v1/learning/sessions/{id}/answers"];
+    expect(
+      answersPath?.get,
+      "getSessionAnswersが同一path item内に存在すること",
+    ).toBeDefined();
+    expect(
+      answersPath?.post,
+      "submitAnswerが同一path item内に存在すること",
+    ).toBeDefined();
+  });
+});

--- a/api/src/types/generated/api.d.ts
+++ b/api/src/types/generated/api.d.ts
@@ -186,6 +186,24 @@ export interface paths {
     /** @description Get answer history for session */
     get: operations["QuizLearning_getSessionAnswers"];
     put?: never;
+    /** @description Submit answer to quiz in session (creates a new Attempt) */
+    post: operations["QuizLearning_submitAnswer"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/sessions/{id}/answers/{quizId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Check if quiz is already answered in session */
+    get: operations["QuizLearning_getSessionAnswer"];
+    put?: never;
     post?: never;
     delete?: never;
     options?: never;
@@ -219,40 +237,6 @@ export interface paths {
     };
     /** @description Get session statistics */
     get: operations["QuizLearning_getSessionStatistics"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/quiz/v1/learning/sessions/{sessionId}/answers": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** @description Submit answer to quiz in session */
-    post: operations["QuizLearning_submitAnswer"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/quiz/v1/learning/sessions/{sessionId}/answers/{quizId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** @description Check if quiz is already answered in session */
-    get: operations["QuizLearning_getSessionAnswer"];
     put?: never;
     post?: never;
     delete?: never;
@@ -1354,7 +1338,6 @@ export interface components {
       firstQuiz?: components["schemas"]["QuizResponse"];
     };
     SubmitAnswerRequest: {
-      sessionId: components["schemas"]["SessionId"];
       quizId: components["schemas"]["QuizId"];
       answer: components["schemas"]["Answer"];
     };
@@ -1907,6 +1890,76 @@ export interface operations {
       };
     };
   };
+  QuizLearning_submitAnswer: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["SessionId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SubmitAnswerRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded and a new resource has been created as a result. */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SubmitAnswerResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["ValidationError"]
+            | components["schemas"]["NotFoundError"]
+            | components["schemas"]["ConflictError"];
+        };
+      };
+    };
+  };
+  QuizLearning_getSessionAnswer: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["SessionId"];
+        quizId: components["schemas"]["QuizId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AttemptWithAnswer"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
   QuizLearning_getNextQuiz: {
     parameters: {
       query?: never;
@@ -1978,76 +2031,6 @@ export interface operations {
               recommendations: string[];
             };
           };
-        };
-      };
-      /** @description An unexpected error response. */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["NotFoundError"];
-        };
-      };
-    };
-  };
-  QuizLearning_submitAnswer: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        sessionId: components["schemas"]["SessionId"];
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["SubmitAnswerRequest"];
-      };
-    };
-    responses: {
-      /** @description The request has succeeded. */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SubmitAnswerResponse"];
-        };
-      };
-      /** @description An unexpected error response. */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json":
-            | components["schemas"]["ValidationError"]
-            | components["schemas"]["NotFoundError"]
-            | components["schemas"]["ConflictError"];
-        };
-      };
-    };
-  };
-  QuizLearning_getSessionAnswer: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        sessionId: components["schemas"]["SessionId"];
-        quizId: components["schemas"]["QuizId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description The request has succeeded. */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AttemptWithAnswer"];
         };
       };
       /** @description An unexpected error response. */

--- a/api/src/types/generated/api.d.ts
+++ b/api/src/types/generated/api.d.ts
@@ -4,6 +4,263 @@
  */
 
 export interface paths {
+  "/api/quiz/v1/learning/decks": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Create new deck from manual selection */
+    post: operations["QuizLearning_createDeck"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/decks/from-search": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Create deck from search results */
+    post: operations["QuizLearning_createDeckFromSearch"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/decks/mine": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description List user's decks */
+    get: operations["QuizLearning_getMyDecks"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/decks/wrong-questions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Create deck from wrong answers */
+    post: operations["QuizLearning_createDeckFromWrongAnswers"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/decks/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get deck details */
+    get: operations["QuizLearning_getDeck"];
+    put?: never;
+    post?: never;
+    /** @description Delete deck */
+    delete: operations["QuizLearning_deleteDeck"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/published": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get list of published quizzes for learning */
+    get: operations["QuizLearning_getPublishedQuizzes"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/published/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get specific published quiz */
+    get: operations["QuizLearning_getPublishedQuiz"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/sessions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Start new quiz session */
+    post: operations["QuizLearning_startSession"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/sessions/mine": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get user's sessions */
+    get: operations["QuizLearning_getMySessions"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/sessions/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get session details with progress */
+    get: operations["QuizLearning_getSession"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** @description Update session (mark completed, etc.) */
+    patch: operations["QuizLearning_updateSession"];
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/sessions/{id}/answers": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get answer history for session */
+    get: operations["QuizLearning_getSessionAnswers"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/sessions/{id}/next-quiz": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get next quiz in session */
+    get: operations["QuizLearning_getNextQuiz"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/sessions/{id}/statistics": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get session statistics */
+    get: operations["QuizLearning_getSessionStatistics"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/sessions/{sessionId}/answers": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Submit answer to quiz in session */
+    post: operations["QuizLearning_submitAnswer"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/quiz/v1/learning/sessions/{sessionId}/answers/{quizId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Check if quiz is already answered in session */
+    get: operations["QuizLearning_getSessionAnswer"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/quiz/v1/manage/quizzes": {
     parameters: {
       query?: never;
@@ -213,6 +470,229 @@ export interface paths {
     get: operations["Search_searchQuizzes"];
     put?: never;
     post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/accounts": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Create user account (optional upgrade from anonymous) */
+    post: operations["UserSession_createUserAccount"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/accounts/{accountId}/link-identity": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Link user identity to account */
+    post: operations["UserSession_linkUserIdentity"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/accounts/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get user profile */
+    get: operations["UserSession_getUserAccount"];
+    put?: never;
+    post?: never;
+    /** @description Delete user account (keeps identity and content) */
+    delete: operations["UserSession_deleteUserAccount"];
+    options?: never;
+    head?: never;
+    /** @description Update user account */
+    patch: operations["UserSession_updateUserAccount"];
+    trace?: never;
+  };
+  "/api/user/v1/identities": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Create anonymous user identity */
+    post: operations["UserSession_createUserIdentity"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/identities/anonymous/{anonymousId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get user identity by anonymous ID */
+    get: operations["UserSession_getUserIdentityByAnonymousId"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/identities/verify": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Verify user identity */
+    post: operations["UserSession_verifyUserIdentity"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/profiles/{userId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get complete user profile */
+    get: operations["UserSession_getUserProfile"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/profiles/{userId}/attempts": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get user's answer history */
+    get: operations["UserSession_getUserAttempts"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/profiles/{userId}/attempts/statistics": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get user's attempt statistics */
+    get: operations["UserSession_getUserAttemptStatistics"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/profiles/{userId}/attempts/wrong": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get wrong answers for review */
+    get: operations["UserSession_getWrongAttempts"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/profiles/{userId}/statistics": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Get user learning statistics */
+    get: operations["UserSession_getUserStatistics"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/sessions/refresh": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Refresh session token */
+    post: operations["UserSession_refreshSessionToken"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/user/v1/sessions/validate": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Validate session token */
+    post: operations["UserSession_validateSessionToken"];
     delete?: never;
     options?: never;
     head?: never;
@@ -1002,6 +1482,585 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  QuizLearning_createDeck: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateDeckRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["CreateDeckResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ValidationError"];
+        };
+      };
+    };
+  };
+  QuizLearning_createDeckFromSearch: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateDeckFromSearchRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["CreateDeckResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ValidationError"];
+        };
+      };
+    };
+  };
+  QuizLearning_getMyDecks: {
+    parameters: {
+      query: {
+        userId: components["schemas"]["UserId"];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PaginationRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["DeckListResponse"];
+        };
+      };
+    };
+  };
+  QuizLearning_createDeckFromWrongAnswers: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          name?: string;
+          description?: string;
+          userId: components["schemas"]["UserId"];
+          /**
+           * Format: int32
+           * @default 50
+           */
+          maxQuizzes?: number;
+          /**
+           * Format: int32
+           * @default 30
+           */
+          sinceDays?: number;
+        };
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["CreateDeckResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ValidationError"];
+        };
+      };
+    };
+  };
+  QuizLearning_getDeck: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["DeckId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["DeckWithQuizzes"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  QuizLearning_deleteDeck: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["DeckId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description There is no content to send for this request, but the headers may be useful.  */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["NotFoundError"]
+            | components["schemas"]["ForbiddenError"];
+        };
+      };
+    };
+  };
+  QuizLearning_getPublishedQuizzes: {
+    parameters: {
+      query?: {
+        tags?: string[];
+        difficulty?: string;
+        answerType?: components["schemas"]["AnswerType"];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PaginationRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["QuizSummaryListResponse"];
+        };
+      };
+    };
+  };
+  QuizLearning_getPublishedQuiz: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["QuizId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["QuizResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  QuizLearning_startSession: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["StartSessionRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["StartSessionResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["ValidationError"]
+            | components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  QuizLearning_getMySessions: {
+    parameters: {
+      query: {
+        userId: components["schemas"]["UserId"];
+        isCompleted?: boolean;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PaginationRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SessionListResponse"];
+        };
+      };
+    };
+  };
+  QuizLearning_getSession: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["SessionId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["QuizSessionWithProgress"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  QuizLearning_updateSession: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["SessionId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateSessionRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["QuizSessionWithProgress"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["NotFoundError"]
+            | components["schemas"]["ValidationError"];
+        };
+      };
+    };
+  };
+  QuizLearning_getSessionAnswers: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["SessionId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PaginationRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AttemptHistoryResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  QuizLearning_getNextQuiz: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["SessionId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["QuizResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["NotFoundError"]
+            | components["schemas"]["ConflictError"];
+        };
+      };
+    };
+  };
+  QuizLearning_getSessionStatistics: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["SessionId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            session: components["schemas"]["QuizSessionWithProgress"];
+            performance: {
+              /** Format: int32 */
+              totalTime: number;
+              /** Format: float */
+              averageTimePerQuiz: number;
+              streaks: {
+                /** Format: int32 */
+                current: number;
+                /** Format: int32 */
+                best: number;
+              };
+              scoreDistribution: Record<string, never>;
+            };
+            insights: {
+              strongAreas: string[];
+              improvementAreas: string[];
+              recommendations: string[];
+            };
+          };
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  QuizLearning_submitAnswer: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        sessionId: components["schemas"]["SessionId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SubmitAnswerRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SubmitAnswerResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["ValidationError"]
+            | components["schemas"]["NotFoundError"]
+            | components["schemas"]["ConflictError"];
+        };
+      };
+    };
+  };
+  QuizLearning_getSessionAnswer: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        sessionId: components["schemas"]["SessionId"];
+        quizId: components["schemas"]["QuizId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AttemptWithAnswer"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
   QuizManagement_listQuizzes: {
     parameters: {
       query?: {
@@ -1223,6 +2282,590 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["QuizSummaryListResponse"];
+        };
+      };
+    };
+  };
+  UserSession_createUserAccount: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          name: string;
+          email?: string;
+          userId: components["schemas"]["UserId"];
+        };
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["CreateUserAccountResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["ValidationError"]
+            | components["schemas"]["ConflictError"];
+        };
+      };
+    };
+  };
+  UserSession_linkUserIdentity: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        accountId: components["schemas"]["UserAccountId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          userId: components["schemas"]["UserId"];
+        };
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UserProfileResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["NotFoundError"]
+            | components["schemas"]["ValidationError"];
+        };
+      };
+    };
+  };
+  UserSession_getUserAccount: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["UserAccountId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UserAccount"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  UserSession_deleteUserAccount: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["UserAccountId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description There is no content to send for this request, but the headers may be useful.  */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  UserSession_updateUserAccount: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["UserAccountId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateUserAccountRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UserAccount"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["NotFoundError"]
+            | components["schemas"]["ValidationError"];
+        };
+      };
+    };
+  };
+  UserSession_createUserIdentity: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          anonymousId: string;
+          deviceFingerprint: string;
+        };
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            userIdentity: components["schemas"]["UserIdentity"];
+            sessionToken: string;
+          };
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["ValidationError"]
+            | components["schemas"]["ConflictError"];
+        };
+      };
+    };
+  };
+  UserSession_getUserIdentityByAnonymousId: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        anonymousId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UserIdentity"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  UserSession_verifyUserIdentity: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          userId: components["schemas"]["UserId"];
+          anonymousId: string;
+          deviceFingerprint: string;
+        };
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            userIdentity: components["schemas"]["UserIdentity"];
+            isValid: boolean;
+            sessionToken?: string;
+          };
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["NotFoundError"]
+            | components["schemas"]["ValidationError"];
+        };
+      };
+    };
+  };
+  UserSession_getUserProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        userId: components["schemas"]["UserId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UserProfileResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  UserSession_getUserAttempts: {
+    parameters: {
+      query?: {
+        sessionId?: components["schemas"]["SessionId"];
+        quizId?: components["schemas"]["QuizId"];
+        isCorrect?: boolean;
+        startDate?: string;
+        endDate?: string;
+      };
+      header?: never;
+      path: {
+        userId: components["schemas"]["UserId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PaginationRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AttemptHistoryResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  UserSession_getUserAttemptStatistics: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        userId: components["schemas"]["UserId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AttemptStatistics"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  UserSession_getWrongAttempts: {
+    parameters: {
+      query?: {
+        sinceDays?: number;
+        tags?: string[];
+      };
+      header?: never;
+      path: {
+        userId: components["schemas"]["UserId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PaginationRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AttemptHistoryResponse"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  UserSession_getUserStatistics: {
+    parameters: {
+      query?: {
+        period?: "day" | "week" | "month" | "all";
+      };
+      header?: never;
+      path: {
+        userId: components["schemas"]["UserId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: int32 */
+            totalQuizzes: number;
+            /** Format: int32 */
+            totalAttempts: number;
+            /** Format: int32 */
+            correctAnswers: number;
+            /** Format: float */
+            averageCorrectRate: number;
+            /** Format: int32 */
+            streak: number;
+            detailed: {
+              dailyActivity: {
+                date: string;
+                /** Format: int32 */
+                attempts: number;
+                /** Format: float */
+                correctRate: number;
+                /** Format: int32 */
+                timeSpent: number;
+              }[];
+              topicPerformance: {
+                topic: string;
+                /** Format: int32 */
+                attempts: number;
+                /** Format: float */
+                correctRate: number;
+                /** Format: float */
+                improvement: number;
+              }[];
+              learningStreak: {
+                /** Format: int32 */
+                current: number;
+                /** Format: int32 */
+                longest: number;
+                lastActiveDate: string;
+              };
+            };
+          };
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotFoundError"];
+        };
+      };
+    };
+  };
+  UserSession_refreshSessionToken: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          userId: components["schemas"]["UserId"];
+          currentToken: string;
+          deviceFingerprint: string;
+        };
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            newToken: string;
+            expiresAt: components["schemas"]["UtcDateTime"];
+          };
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["UnauthorizedError"]
+            | components["schemas"]["ValidationError"];
+        };
+      };
+    };
+  };
+  UserSession_validateSessionToken: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          userId: components["schemas"]["UserId"];
+          token: string;
+        };
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            isValid: boolean;
+            expiresAt?: components["schemas"]["UtcDateTime"];
+            userIdentity?: components["schemas"]["UserIdentity"];
+          };
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ValidationError"];
         };
       };
     };

--- a/docs/project/adr/0025-update-endpoint-http-method-policy.md
+++ b/docs/project/adr/0025-update-endpoint-http-method-policy.md
@@ -1,0 +1,109 @@
+# ADR-0025: 更新系エンドポイントのHTTPメソッド方針（TypeSpec/Hono実装層）
+
+## Status
+
+Proposed
+
+## Context
+
+### Background
+
+issue #39「仕様/ADR正規化」は完了条件の一つとして「HTTPメソッド：PUT → PATCHに統一（ADR・TypeSpec・Hono handler）」を挙げていた。しかし調査の結果、`docs/project/adr/` 配下にPUT/PATCHへ言及するADRは1件も存在しなかった。issue #39の実装（PR #62）はこの食い違いを踏まえ、`docs/project/api-design/` 配下14箇所のドキュメント文言をPUT→PATCHへ統一したが、PR #62本文で「ADR配下にPUTは0件」「instructions/ とコードは据え置き」と明言し、**ADR作成とTypeSpec/Hono実装への反映を意図的にスコープ外**とした。
+
+一方、`docs/project/api-design/design-principles.md` は最上位の設計原則として
+
+```http
+GET     /resource              # 一覧取得
+POST    /resource              # 新規作成
+PATCH   /resource/{id}         # リソース更新（部分更新）
+DELETE  /resource/{id}         # 削除
+```
+
+を規定するに至った（PR #62でPUTの記載を削除済み）ものの、これは「更新系はPATCH」という原則の宣言に留まり、「作成」「状態遷移」に該当する操作をPATCHとPOSTのどちらで扱うかの判断基準までは示していない。
+
+本PR（#61）は quiz-learning・user-session コンテキストを初めて TypeSpec/OpenAPI に出力する。このタイミングで、issue #39/PR #62が意図的に残した「実装層での判断基準」を確定する必要がある。
+
+### Drivers
+
+- `docs/instructions/shared/workflow/00.02_workflow.md:179` — 「API設計方針やエラーハンドリング戦略等の重要決定について、ADRでの記録をユーザーに提案する」
+- `docs/instructions/shared/workflow/04.02_api-design.md:105-111` — HTTPメソッドの冪等性・安全性・レスポンスコード表を定義（PATCHは非冪等）
+- `docs/instructions/shared/workflow/04.02_api-design.md:82-87` — 操作の複雑さに応じた名詞API/動詞APIの判断表
+- `docs/project/ddd-design/2.09_bounded-context-definition/quiz-learning-context.md` — 回答提出・セッション完了のドメイン実装（`answerQuiz()`, `endSession()`）
+
+## Decision
+
+### Chosen Option
+
+実装層（TypeSpec operations、および将来のHono handler）でも PUT は使わず、更新系エンドポイントは原則 **PATCH** を用いる。ただし判断基準は「リクエストモデルの形（全項目optionalかどうか）」ではなく、**操作の意味論**（新規作成か、既存リソースの部分更新か、複雑な状態遷移か）で決める。
+
+| 判断 | 採用verb | 根拠 |
+|---|---|---|
+| 既存リソースの部分更新（フィールド単位の変更） | PATCH | `04.02_api-design.md:105-111` の定義に合致。冪等性は失うが、対象リクエストは元々全項目optionalで実害は小さい |
+| 新規エンティティの生成（サーバー側でIDを採番） | POST（名詞API、`POST /{collection}`） | 非冪等な作成操作。`04.02_api-design.md:82-87` の判断表・`design-principles.md` の「POST=新規作成」に合致 |
+| 複数ステップの業務処理・状態遷移 | POST（動詞API、`POST /{resource}/{action}`） | `04.02_api-design.md:86-87` の判断表に合致。本PRのスコープでは未着手（Neutral参照） |
+
+### 本PRでの適用
+
+| Endpoint | 旧 | 新 | 理由 |
+|---|---|---|---|
+| `PATCH /api/quiz/v1/learning/sessions/{id}` (`updateSession`) | PUT | **PATCH** | `UpdateSessionRequest = { isCompleted?: boolean }` は単一フィールドの部分更新として扱う。厳密には「セッション完了」という状態遷移的側面もあり `POST /sessions/{id}/complete` という動詞API化も検討したが（Alternatives参照）、影響範囲を本PRのスコープに閉じるため今回はPATCHのまま据え置く |
+| `POST /api/quiz/v1/learning/sessions/{id}/answers` (`submitAnswer`) | PUT | **POST** | ドメイン実装 `quiz-learning-context.md` の `answerQuiz()` は `AnswerId.generate()` で新規IDを採番し `Answer.create()` でエンティティを生成する、非冪等な作成操作。PATCHは不適。レスポンスも201 Createdへ変更した |
+| `PATCH /api/user/v1/accounts/{id}` (`updateUserAccount`) | PUT | **PATCH** | `UpdateUserAccountRequest = { name?, email? }` は素直な部分更新 |
+
+### Alternatives Considered
+
+| 選択肢 | メリット | デメリット | 評価 |
+|--------|----------|------------|------|
+| 全エンドポイントをPUTのまま据え置く | 変更コストゼロ | `design-principles.md` の方針（PATCH統一）およびissue #39の意図と矛盾したまま残る | ★ |
+| `updateSession` を `POST /sessions/{id}/complete` に変更（動詞API化） | `docs/project/api-design/api-catalog/02-quiz-learning.md:104-106` の動詞API規定（complete/pause/resume）と完全に整合する | ルート設計・レスポンス形状の変更を伴い、pause/resume等の姉妹エンドポイント実装が前提になるためスコープが本PRを超える | ★★ |
+| **`updateSession` はPATCHのまま維持し、判断基準のみ本ADRで明文化** | 変更を最小化しつつ判断基準を明文化。将来pause/resumeを追加する際の設計指針として機能する | 「複雑な状態遷移」的操作が形式上PATCHに紛れる点は残る（Negative参照） | ★★★ |
+
+## Consequences
+
+### Positive
+
+- TypeSpec全体でPUTが0件になり、`design-principles.md` の方針と実装が整合する
+- verb選定基準（意味論ベース、モデルの形だけで判断しない）が明文化され、今後 quiz-management 以外のコンテキストを実装する際の指針になる
+- `submitAnswer` が正しく201 Createdを返すようになり、`04.02_api-design.md:108` のPOSTレスポンス規定（201, 400, 409）とも整合する
+
+### Negative
+
+- `04.02_api-design.md:110` はPATCHを非冪等と定義しており、PUT→PATCHは形式上冪等性を失う。ただし対象の2エンドポイント（`updateSession`, `updateUserAccount`）は元々リクエストモデルが全項目optionalであり、実害はない
+- `updateSession` は意味論上「状態遷移」の性質も持つが、今回はPATCHのまま据え置いた。将来 pause/resume を実装する際に再設計が必要になる可能性がある（Neutral参照）
+
+### Neutral
+
+- `updateSession` の動詞API化（`POST /sessions/{id}/complete`、および `pause`/`resume`）は将来のスコープとして残す。実装する場合は本ADRをSupersedeする新ADRを起票する
+- 他のcreate系エンドポイント（`createQuiz`, `startSession`, `createDeck`, `createUserAccount` 等）は現状すべて200を返しており、201への統一は本ADRのスコープ外（別issueで扱う）
+
+### Risks and Mitigation
+
+| リスク | 発生確率 | 影響度 | 対策 |
+|--------|----------|--------|------|
+| 将来 quiz-management 以外のコンテキストで再び「モデルの形」だけでverbを判断してしまう | 中 | 中 | 本ADRの判断基準表をレビュー観点として `docs/instructions/shared/workflow/04.02_api-design.md` からも参照させる |
+
+## Implementation Notes
+
+### Action Items
+
+- [x] `api/spec/operations/quiz-learning.tsp`: `updateSession` を `@patch(#{ implicitOptionality: false })`、`submitAnswer` を `@post`（201 Created）に変更
+- [x] `api/spec/operations/user-session.tsp`: `updateUserAccount` を `@patch(#{ implicitOptionality: false })` に変更
+- [ ] 将来: `updateSession` の動詞API化（`complete`/`pause`/`resume`）を実装する場合は本ADRをSupersedeする新ADRを起票する
+- [ ] 将来: create系エンドポイントの201統一を別issueで検討する
+
+## References
+
+- issue #39, #40
+- PR #61, #62
+- `docs/project/api-design/design-principles.md`
+- `docs/instructions/shared/workflow/04.02_api-design.md`
+- `docs/project/api-design/api-catalog/02-quiz-learning.md`
+- `docs/project/ddd-design/2.09_bounded-context-definition/quiz-learning-context.md`
+- ADR-0022（TypeSpecスキーマファースト開発方針）
+
+---
+
+**Created**: 2026-08-12
+**Last Updated**: 2026-08-12
+**Authors**: Claude (Opus 5, background session)
+**Reviewers**: [@tanacchi](https://github.com/tanacchi)

--- a/docs/project/adr/README.md
+++ b/docs/project/adr/README.md
@@ -26,6 +26,9 @@
 | [0018](0018-domain-service-extraction.md) | ドメインサービス抽出決定 | Proposed | 2025-07-28 | 4つのドメインサービス抽出 |
 | [0019](0019-repository-pattern-adoption.md) | リポジトリパターン採用決定 | Proposed | 2025-07-28 | 集約単位リポジトリ採用 |
 | [0020](0020-bdd-testing-framework.md) | BDDテスティングフレームワーク選定 | Proposed | 2025-01-31 | Cucumber.js + Vitest採用決定 |
+| [0025](0025-update-endpoint-http-method-policy.md) | 更新系エンドポイントのHTTPメソッド方針 | Proposed | 2026-08-12 | TypeSpec/Hono実装層でのPATCH/POST判断基準を確定 |
+
+> **注記**: 0021〜0024は本PR時点で他PRにより並行して番号確保・追加作業中のため、このテーブルは0025のみ追記している。マージ順によっては本テーブルの手動コンフリクト解消が必要。
 
 ## ステータス定義
 

--- a/docs/project/api-design/README.md
+++ b/docs/project/api-design/README.md
@@ -43,7 +43,7 @@ Your QuizアプリケーションにおけるバックエンドAPIの包括的�
 
 ```text
 UI Flow: ホーム → 一覧 → 回答 → 結果
-API Flow: GET /api/quiz/v1/learning/published → POST /api/quiz/v1/learning/decks → GET /api/user/v1/sessions/:id → PUT /api/quiz/v1/learning/sessions/:id/answers
+API Flow: GET /api/quiz/v1/learning/published → POST /api/quiz/v1/learning/decks → GET /api/user/v1/sessions/:id → POST /api/quiz/v1/learning/sessions/:id/answers
 ```
 
 ### クイズ作成フロー

--- a/docs/project/api-design/api-catalog/02-quiz-learning.md
+++ b/docs/project/api-design/api-catalog/02-quiz-learning.md
@@ -98,7 +98,7 @@ interface CreateDeckResponse {
 ```http
 POST   /api/quiz/v1/learning/sessions
 GET    /api/quiz/v1/learning/sessions/:id
-PUT    /api/quiz/v1/learning/sessions/:id
+PATCH  /api/quiz/v1/learning/sessions/:id
 
 # 動詞API (セッション制御)
 POST   /api/quiz/v1/learning/sessions/:id/complete


### PR DESCRIPTION
Closes #40

## 変更内容

- `api/spec/main.tsp` でコメントアウトされていた `quiz-learning.tsp` / `user-session.tsp` の import を有効化
- `updateSession`（quiz-learning）・`updateUserAccount`（user-session）を `@put` → `@patch` に変更
- `submitAnswer`（quiz-learning）を `@put` → `@post` に変更（下記「判断事項」参照）
- 上記に伴い `api/src/types/generated/api.d.ts` を `gen-types` で再生成（手動編集なし）

## 変更理由

issue #40 の要求どおり、学習コンテキスト（デッキ・セッション・解答）とユーザーセッションコンテキスト（匿名ID・アカウント・統計）を OpenAPI 出力に含める。2025-08-05 に型生成パイプライン確立のため全 operations が一括コメントアウトされて以降、quiz-management・search は順次復活していたが、この 2 ファイルだけ取り残されていた（理由を書いた文書・コミットメッセージは見当たらず）。

あわせて issue #39 が提起する PUT→PATCH 統一方針を、コメントアウトが解けたことで初めて反映可能になった `@put` 3 箇所に適用した。

## 判断事項（issue 本文からの逸脱・スコープ判断）

作業前の調査で issue 本文と現物にズレがあったため、以下の判断で進めました。異論があればコメントください。

1. **`submitAnswer` は PATCH ではなく POST にしました。**
   `SubmitAnswerRequest`（sessionId・quizId・answer が全て必須）は実体が Attempt の新規作成で、`docs/project/api-design/design-principles.md` の POST=作成 に沿います。他の 2 件（`updateSession` / `updateUserAccount`）はリクエストモデルが全項目 optional で PATCH に自然に合致するため、そのまま PATCH にしています。
2. **生成 OpenAPI YAML（`api/spec/generated/api.yaml`）はコミットしていません。**
   issue #40 は `api/spec/dist/openapi.yaml` へのコミットを求めていますが、`tspconfig.yaml` の実出力先は `generated/api.yaml` で、`api/spec/.gitignore` が `generated/` と `dist/` を除外しています。既存運用（中間成果物は gitignore、`api/src/types/generated/api.d.ts` のみコミット）に合わせました。なお `docs/instructions/shared/tools/typespec.md` は「生成された OpenAPI は Git 管理対象とする」と記載しており実設定と矛盾しています。この矛盾の解消は本 PR のスコープ外です。
3. **「search operations 解禁」「offline-sync コンテキスト」は対象外です。**
   `search.tsp` の import は本 PR 着手前から既に有効でした。ファイル内部のコメントアウト API（タグ検索・分析系）は `models/tag.tsp` に未定義のモデル（`TagSearchRequest` 等）を参照しビルド不能なうえ、コメントに「初期リリース版では未実装」と明記されています。offline-sync は `.tsp` ファイル自体が存在しません。両方とも別 issue での対応を提案します。
4. issue #39 の他項目（解答モデル 4 種 Union 化、QuizPocket 命名統一、docs の PUT 表記修正）は、#39 自身が「実装コードの変更は行わない（docs/ADR のみ）」と宣言しているためスコープ外としました。

## 確認事項

- [x] `pnpm --filter quiz-api-spec build` 終了コード 0（学習・ユーザーセッション全パス出力、`put:` 0件を確認）
- [x] `pnpm --filter api typecheck` 終了コード 0
- [x] `pnpm --filter quiz-api-spec test` 全 37 テスト通過
- [x] `pnpm lint`（biome + markdownlint）終了コード 0
- [x] `pnpm test`（test:api / test:ui / test:scripts）終了コード 0、カバレッジ閾値エラーなし
- [x] クリーンビルド再現性確認（`build` → `format:biome` の順で実行すると `api.d.ts` がコミット内容とバイト単位で一致することを確認）
- [x] `git status` が working tree clean
- [ ] `api/src/types/generated/api.d.ts` の差分（+1748/-105 行）は生成物のため、1PR 500行以内の目安を超過しています。中身は新規追加された learning/user-session コンテキストの型のみです。

