### PR TITLE
ui: APIエラーモデルの型定義を追加する（ADR0011 / issue #41 1/3）

### DIFF
--- a/ui/src/types/api.test.ts
+++ b/ui/src/types/api.test.ts
@@ -1,0 +1,59 @@
+import { isApiErrorBody } from "./api";
+
+describe("isApiErrorBody", () => {
+  it("code と message を持つオブジェクトを true と判定する", () => {
+    expect(isApiErrorBody({ code: 404, message: "Not Found" })).toBe(true);
+  });
+
+  it("details / requestId / fieldErrors を含むオブジェクトを true と判定する", () => {
+    expect(
+      isApiErrorBody({
+        code: 400,
+        message: "Validation failed",
+        details: "id is required",
+        requestId: "req-1",
+        fieldErrors: { question: "required" },
+      }),
+    ).toBe(true);
+  });
+
+  it("code が number でない場合は false を返す", () => {
+    expect(isApiErrorBody({ code: "404", message: "Not Found" })).toBe(false);
+  });
+
+  it("message が string でない場合は false を返す", () => {
+    expect(isApiErrorBody({ code: 404, message: 123 })).toBe(false);
+  });
+
+  it("details が string でない場合は false を返す", () => {
+    expect(isApiErrorBody({ code: 400, message: "x", details: 1 })).toBe(false);
+  });
+
+  it("requestId が string でない場合は false を返す", () => {
+    expect(isApiErrorBody({ code: 400, message: "x", requestId: 1 })).toBe(
+      false,
+    );
+  });
+
+  it("fieldErrors がオブジェクトでない場合は false を返す", () => {
+    expect(
+      isApiErrorBody({ code: 400, message: "x", fieldErrors: "invalid" }),
+    ).toBe(false);
+  });
+
+  it("null を false と判定する", () => {
+    expect(isApiErrorBody(null)).toBe(false);
+  });
+
+  it("オブジェクトでない値を false と判定する", () => {
+    expect(isApiErrorBody("error")).toBe(false);
+    expect(isApiErrorBody(42)).toBe(false);
+    expect(isApiErrorBody(undefined)).toBe(false);
+  });
+
+  it("code / message を欠くオブジェクトを false と判定する", () => {
+    expect(isApiErrorBody({})).toBe(false);
+    expect(isApiErrorBody({ code: 404 })).toBe(false);
+    expect(isApiErrorBody({ message: "x" })).toBe(false);
+  });
+});

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -1,0 +1,91 @@
+/**
+ * API のワイヤ形とエラーモデル。
+ *
+ * `ApiErrorBody` は TypeSpec (`api/spec/common/errors.tsp`) から生成される
+ * `api/src/types/generated/api.d.ts` の `ErrorResponse` と一致する。
+ * `code` は HTTP ステータスコードと同値。
+ */
+export interface ApiErrorBody {
+  readonly code: number;
+  readonly message: string;
+  readonly details?: string;
+  readonly requestId?: string;
+  readonly fieldErrors?: Readonly<Record<string, string>>;
+}
+
+/** `unknown` を「プロパティに対して安全にアクセスできるオブジェクト」に絞り込む。 */
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+/**
+ * `unknown` を `ApiErrorBody` に絞り込む型ガード。
+ * レスポンスボディの JSON パース結果は `unknown` になるため、
+ * `as` を使わずここで安全に検証する。
+ */
+export const isApiErrorBody = (value: unknown): value is ApiErrorBody => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (typeof value["code"] !== "number") {
+    return false;
+  }
+  if (typeof value["message"] !== "string") {
+    return false;
+  }
+
+  const details = value["details"];
+  if (details !== undefined && typeof details !== "string") {
+    return false;
+  }
+
+  const requestId = value["requestId"];
+  if (requestId !== undefined && typeof requestId !== "string") {
+    return false;
+  }
+
+  const fieldErrors = value["fieldErrors"];
+  if (fieldErrors !== undefined && !isRecord(fieldErrors)) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * UI 内部で扱う HTTP エラーの判別共用体。
+ * neverthrow の `Result<T, AppError>` の失敗側として使う。
+ */
+export type AppError =
+  | {
+      readonly kind: "network";
+      readonly message: string;
+      readonly cause: unknown;
+    }
+  | { readonly kind: "timeout"; readonly message: string }
+  | {
+      readonly kind: "http";
+      readonly status: number;
+      readonly body: ApiErrorBody;
+    }
+  | {
+      readonly kind: "unexpectedResponse";
+      readonly status: number;
+      readonly message: string;
+    }
+  | {
+      readonly kind: "parse";
+      readonly message: string;
+      readonly cause: unknown;
+    };
+
+/**
+ * 非同期処理の状態を表す判別共用体。
+ * `docs/instructions/shared/languages/typescript.md` が推奨する
+ * `{status:'loading'}|{status:'success',data}|{status:'error',error}`
+ * のパターンに `idle`（未実行）を加えたもの。
+ */
+export type AsyncState<T> =
+  | { readonly status: "idle" }
+  | { readonly status: "loading" }
+  | { readonly status: "success"; readonly data: T }
+  | { readonly status: "error"; readonly error: AppError };

--- a/ui/src/types/env.d.ts
+++ b/ui/src/types/env.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Next.js は `process.env.NEXT_PUBLIC_*` をドットアクセスの形でしか
+ * ビルド時にインライン化しない。`noPropertyAccessFromIndexSignature`
+ * が有効な状態でドットアクセスを型エラーにしないため、
+ * `NodeJS.ProcessEnv` へプロパティを宣言マージする。
+ */
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      readonly NEXT_PUBLIC_API_URL?: string;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
## 変更内容

- `ui/src/types/api.ts`: `ApiErrorBody`（TypeSpec 生成型準拠のワイヤ形）、`AppError` 判別共用体、`AsyncState<T>` を追加
- `unknown` → `ApiErrorBody` の絞り込みを行う手書き型ガード `isApiErrorBody`（`as` 不使用）
- `ui/src/types/env.d.ts`: `NEXT_PUBLIC_API_URL` を `NodeJS.ProcessEnv` に宣言マージ

## 変更理由

issue #41「ui: 状態管理(Jotai)＋HTTPクライアント(fetch)基盤整備」の一部。ADR-0011（neverthrow による Result 型統一）の実装に向けて、まず UI 側で扱うエラーモデルの型を整備する。

エラーレスポンスの形は `api/spec/common/errors.tsp` → 生成型 `api/src/types/generated/api.d.ts` → Hono 実装 `mapErrorToResponse` の実際の形（`{ code, message, details?, requestId?, fieldErrors? }`）に合わせた。`docs/project/api-design/api-catalog/07-common-specs.md` に記載のネスト封筒形は未実装のため採用していない。

`docs/instructions/shared/languages/typescript.md` が禁止する `any` / `as` / non-null assertion を一切使わず、`unknown` の絞り込みは手書きの型ガードで行っている。

この PR は #41 全体を 500 行以内の PR に分割した 1/3。#41 の残り（HTTPクライアント本体・jotai atoms）はこのブランチに依存する stacked PR として続けて出す。

## 確認事項

- [x] 差分行数が500行以内（165行）
- [x] `pnpm --filter ui typecheck` 通過
- [x] `pnpm --filter ui test` 通過（17ファイル55テスト、既存回帰なし）
- [x] `pnpm exec biome check` 通過
- [x] TDD（Red→Green）で実装