### PR TITLE
api: Search 本番D1接続（MockSearchRepository → D1実装・DI差し替え）

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
     "build:cf-typegen": "wrangler types --env-interface CloudflareBindings",
     "build:gen-schema": "pnpm --filter quiz-api-spec build && pnpm format",
     "db:mig:apply": "wrangler d1 migrations apply quiz-db --local",
+    "db:mig:apply:remote": "wrangler d1 migrations apply quiz-db --remote",
     "db:mig:create": "wrangler d1 migrations create quiz-db init",
     "db:reset": "rm -rf .wrangler/state && pnpm db:mig:apply && pnpm db:seed",
     "db:seed": "wrangler d1 execute quiz-db --local --file migrations/dev/seed.sql",

--- a/api/src/contexts/search/infrastructure/mappers/search-row.schema.spec.ts
+++ b/api/src/contexts/search/infrastructure/mappers/search-row.schema.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "vitest";
 import {
   isSearchCountRow,
   isSearchRow,
+  parseSearchRows,
   type SearchRow,
+  searchCountRowSchema,
   searchRowSchema,
   toQuizSummary,
 } from "./search-row.schema";
@@ -10,9 +12,13 @@ import {
 describe("search-row.schema", () => {
   /**
    * 有効なD1検索行データを生成するヘルパー関数
+   *
+   * D1の生の行（パース前）を模すため、overridesの型は変換後の SearchRow
+   * ではなく Record<string, unknown> とする（id等はD1から数値で返ることも
+   * あり、パース前はそのままの型で渡せる必要があるため）。
    */
   const createValidRow = (
-    overrides: Partial<SearchRow> = {},
+    overrides: Record<string, unknown> = {},
   ): Record<string, unknown> => ({
     id: "1",
     question: "TypeScriptはJavaScriptのスーパーセットである",
@@ -183,8 +189,19 @@ describe("search-row.schema", () => {
       expect(isSearchCountRow({ total: 42 })).toBe(true);
     });
 
-    test("D1が返す文字列型のtotalも数値に変換されて有効と判定される", () => {
+    test("D1が返す文字列型のtotalはisSearchCountRowでは有効と判定されるのみで、実際の数値変換にはsafeParse().dataを使う必要がある", () => {
+      // isSearchCountRow は型ガード（真偽値のみ）であり、この呼び出し自体は
+      // transform後の値を返さない。D1SearchRepositoryが実際に総数を取り出す
+      // 際は searchCountRowSchema.safeParse(...).data を使う（型ガードの
+      // narrowingだけでは transform 前の値のまま扱ってしまうバグの回帰）
       expect(isSearchCountRow({ total: "42" })).toBe(true);
+
+      const parsed = searchCountRowSchema.safeParse({ total: "42" });
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.total).toBe(42);
+        expect(typeof parsed.data.total).toBe("number");
+      }
     });
 
     test("totalが欠落している場合は無効", () => {
@@ -193,6 +210,58 @@ describe("search-row.schema", () => {
 
     test("totalが数値変換不能な文字列の場合は無効", () => {
       expect(isSearchCountRow({ total: "not-a-number" })).toBe(false);
+    });
+  });
+
+  describe("parseSearchRows", () => {
+    test("全行が有効な場合、validRowsに全件、invalidRowsは空になる", () => {
+      // Arrange
+      const rows = [createValidRow({ id: 1 }), createValidRow({ id: 2 })];
+
+      // Act
+      const { validRows, invalidRows } = parseSearchRows(rows);
+
+      // Assert
+      expect(validRows).toHaveLength(2);
+      expect(invalidRows).toHaveLength(0);
+    });
+
+    test("数値IDの行はvalidRowsの中でzodのtransformにより文字列化される", () => {
+      // isSearchRow による filter だけでは transform が適用されないバグの
+      // 回帰テスト（D1SearchRepository.spec.tsの対応するテストと対）
+      // Arrange
+      const rows = [createValidRow({ id: 42, solution_id: 7, creator_id: 3 })];
+
+      // Act
+      const { validRows } = parseSearchRows(rows);
+
+      // Assert
+      expect(validRows[0]?.id).toBe("42");
+      expect(validRows[0]?.solution_id).toBe("7");
+      expect(validRows[0]?.creator_id).toBe("3");
+      expect(typeof validRows[0]?.id).toBe("string");
+    });
+
+    test("不正な形式の行はinvalidRowsに振り分けられ、validRowsには含まれない", () => {
+      // Arrange
+      const rows = [
+        createValidRow({ id: 1 }),
+        { id: 2 /* question等の必須フィールド欠落 */ },
+      ];
+
+      // Act
+      const { validRows, invalidRows } = parseSearchRows(rows);
+
+      // Assert
+      expect(validRows).toHaveLength(1);
+      expect(validRows[0]?.id).toBe("1");
+      expect(invalidRows).toEqual([{ id: 2 }]);
+    });
+
+    test("空配列を渡した場合、両方とも空配列になる", () => {
+      const { validRows, invalidRows } = parseSearchRows([]);
+      expect(validRows).toEqual([]);
+      expect(invalidRows).toEqual([]);
     });
   });
 });

--- a/api/src/contexts/search/infrastructure/mappers/search-row.schema.spec.ts
+++ b/api/src/contexts/search/infrastructure/mappers/search-row.schema.spec.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "vitest";
+import {
+  isSearchCountRow,
+  isSearchRow,
+  type SearchRow,
+  searchRowSchema,
+  toQuizSummary,
+} from "./search-row.schema";
+
+describe("search-row.schema", () => {
+  /**
+   * 有効なD1検索行データを生成するヘルパー関数
+   */
+  const createValidRow = (
+    overrides: Partial<SearchRow> = {},
+  ): Record<string, unknown> => ({
+    id: "1",
+    question: "TypeScriptはJavaScriptのスーパーセットである",
+    answer_type: "boolean",
+    solution_id: "1",
+    explanation: null,
+    status: "approved",
+    creator_id: "1",
+    created_at: "2024-01-15T00:00:00Z",
+    approved_at: null,
+    tag_names: null,
+    ...overrides,
+  });
+
+  describe("searchRowSchema / isSearchRow", () => {
+    test("必須フィールドのみの行は有効と判定される", () => {
+      // Arrange
+      const row = createValidRow();
+
+      // Act
+      const result = searchRowSchema.safeParse(row);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(isSearchRow(row)).toBe(true);
+    });
+
+    test("D1が返す数値IDは文字列へ変換される", () => {
+      // Arrange
+      const row = createValidRow({
+        id: 1 as unknown as string,
+        solution_id: 2 as unknown as string,
+        creator_id: 3 as unknown as string,
+      });
+
+      // Act
+      const result = searchRowSchema.safeParse(row);
+
+      // Assert
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.id).toBe("1");
+        expect(result.data.solution_id).toBe("2");
+        expect(result.data.creator_id).toBe("3");
+      }
+    });
+
+    test.each([
+      ["boolean"],
+      ["free_text"],
+      ["single_choice"],
+      ["multiple_choice"],
+    ] as const)("answer_type=%s は有効", (answerType) => {
+      const row = createValidRow({ answer_type: answerType });
+      expect(isSearchRow(row)).toBe(true);
+    });
+
+    test("answer_typeが未知の値の場合は無効", () => {
+      const row = createValidRow({
+        answer_type: "unknown_type" as unknown as SearchRow["answer_type"],
+      });
+      expect(isSearchRow(row)).toBe(false);
+    });
+
+    test.each([["pending_approval"], ["approved"], ["rejected"]] as const)(
+      "status=%s は有効",
+      (status) => {
+        const row = createValidRow({ status });
+        expect(isSearchRow(row)).toBe(true);
+      },
+    );
+
+    test("statusが未知の値の場合は無効", () => {
+      const row = createValidRow({
+        status: "unknown_status" as unknown as SearchRow["status"],
+      });
+      expect(isSearchRow(row)).toBe(false);
+    });
+
+    test("必須フィールドが欠落している場合は無効", () => {
+      const { question: _question, ...invalidRow } = createValidRow();
+      expect(isSearchRow(invalidRow)).toBe(false);
+    });
+
+    test("explanation/approved_at/tag_namesはnullを許容する", () => {
+      const row = createValidRow({
+        explanation: null,
+        approved_at: null,
+        tag_names: null,
+      });
+      expect(isSearchRow(row)).toBe(true);
+    });
+  });
+
+  describe("toQuizSummary", () => {
+    test("行データをQuizSummary形状へ変換する", () => {
+      // Arrange
+      const parsed = searchRowSchema.parse(
+        createValidRow({
+          explanation: "TypeScriptに関する解説",
+          approved_at: "2024-01-16T00:00:00Z",
+        }),
+      );
+
+      // Act
+      const summary = toQuizSummary(parsed);
+
+      // Assert
+      expect(summary).toEqual({
+        id: "1",
+        question: "TypeScriptはJavaScriptのスーパーセットである",
+        answerType: "boolean",
+        solutionId: "1",
+        explanation: "TypeScriptに関する解説",
+        status: "approved",
+        creatorId: "1",
+        createdAt: "2024-01-15T00:00:00Z",
+        approvedAt: "2024-01-16T00:00:00Z",
+        tagIds: [],
+      });
+    });
+
+    test("explanation/approved_atがnullの場合、結果オブジェクトにキー自体を含めない", () => {
+      // Arrange（TypeSpec生成型のOptionalフィールドはundefinedでなくキー省略を期待）
+      const parsed = searchRowSchema.parse(
+        createValidRow({ explanation: null, approved_at: null }),
+      );
+
+      // Act
+      const summary = toQuizSummary(parsed);
+
+      // Assert
+      expect(summary).not.toHaveProperty("explanation");
+      expect(summary).not.toHaveProperty("approvedAt");
+    });
+
+    test("tag_namesがnullの場合、tagIdsは空配列になる", () => {
+      const parsed = searchRowSchema.parse(createValidRow({ tag_names: null }));
+      const summary = toQuizSummary(parsed);
+      expect(summary.tagIds).toEqual([]);
+    });
+
+    test("tag_namesは区切り文字char(31)で分割してtagIdsに入れる", () => {
+      const parsed = searchRowSchema.parse(
+        createValidRow({
+          tag_names: "プログラミング\x1fWeb開発\x1fTypeScript",
+        }),
+      );
+      const summary = toQuizSummary(parsed);
+      expect(summary.tagIds).toEqual([
+        "プログラミング",
+        "Web開発",
+        "TypeScript",
+      ]);
+    });
+
+    test("tag_namesが単一タグの場合、要素数1の配列になる", () => {
+      const parsed = searchRowSchema.parse(
+        createValidRow({ tag_names: "プログラミング" }),
+      );
+      const summary = toQuizSummary(parsed);
+      expect(summary.tagIds).toEqual(["プログラミング"]);
+    });
+  });
+
+  describe("isSearchCountRow", () => {
+    test("totalが数値の場合は有効", () => {
+      expect(isSearchCountRow({ total: 42 })).toBe(true);
+    });
+
+    test("D1が返す文字列型のtotalも数値に変換されて有効と判定される", () => {
+      expect(isSearchCountRow({ total: "42" })).toBe(true);
+    });
+
+    test("totalが欠落している場合は無効", () => {
+      expect(isSearchCountRow({})).toBe(false);
+    });
+
+    test("totalが数値変換不能な文字列の場合は無効", () => {
+      expect(isSearchCountRow({ total: "not-a-number" })).toBe(false);
+    });
+  });
+});

--- a/api/src/contexts/search/infrastructure/mappers/search-row.schema.ts
+++ b/api/src/contexts/search/infrastructure/mappers/search-row.schema.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import type { components } from "../../../../types/generated/api";
+
+/**
+ * D1の検索クエリ結果1行分のスキーマ (Zod版)
+ *
+ * quiz-management の d1-types.ts と同じ方針（zodスキーマ + z.infer で
+ * 型を導出）を踏襲し、型アサーション(as)を使わずに行データを検証する。
+ */
+
+/**
+ * D1の数値IDを文字列に変換するスキーマ
+ */
+const d1IdSchema = z.union([z.string(), z.number()]).transform(String);
+
+/**
+ * タグ名の区切り文字（group_concatで使用するUnit Separator, char(31)）
+ */
+const TAG_NAME_SEPARATOR = "\x1f";
+
+export const searchRowSchema = z.object({
+  id: d1IdSchema,
+  question: z.string(),
+  answer_type: z.enum([
+    "boolean",
+    "free_text",
+    "single_choice",
+    "multiple_choice",
+  ]),
+  solution_id: d1IdSchema,
+  explanation: z.string().nullable(),
+  status: z.enum(["pending_approval", "approved", "rejected"]),
+  creator_id: d1IdSchema,
+  // SearchQueryBuilder が strftime で ISO 8601 化して返すため、文字列として受け取る
+  created_at: z.string(),
+  approved_at: z.string().nullable(),
+  // group_concat(t.name, char(31)) の結果。タグが無いクイズは null
+  tag_names: z.string().nullable(),
+});
+
+export type SearchRow = z.infer<typeof searchRowSchema>;
+
+/**
+ * D1クエリ結果がSearchRowの形式かチェックする型ガード
+ */
+export function isSearchRow(data: unknown): data is SearchRow {
+  return searchRowSchema.safeParse(data).success;
+}
+
+/**
+ * 検索件数クエリ（COUNT(*)）の結果行スキーマ
+ */
+export const searchCountRowSchema = z.object({
+  total: z.coerce.number(),
+});
+
+export type SearchCountRow = z.infer<typeof searchCountRowSchema>;
+
+/**
+ * D1クエリ結果がSearchCountRowの形式かチェックする型ガード
+ */
+export function isSearchCountRow(data: unknown): data is SearchCountRow {
+  return searchCountRowSchema.safeParse(data).success;
+}
+
+/**
+ * SearchRow を QuizSummary（TypeSpec生成型）へ変換する
+ *
+ * explanation / approvedAt は Optional フィールドのため、値がない場合は
+ * undefined を代入するのではなくキー自体を省略する
+ * （既存の MockSearchRepository / D1QuizSummaryMapper と同じ方針）。
+ *
+ * @param row - 検証済みのD1検索行
+ * @returns TypeSpec生成の QuizSummary 形状のオブジェクト
+ */
+export function toQuizSummary(
+  row: SearchRow,
+): components["schemas"]["QuizSummary"] {
+  return {
+    id: row.id,
+    question: row.question,
+    answerType: row.answer_type,
+    solutionId: row.solution_id,
+    ...(row.explanation != null && { explanation: row.explanation }),
+    status: row.status,
+    creatorId: row.creator_id,
+    createdAt: row.created_at,
+    ...(row.approved_at != null && { approvedAt: row.approved_at }),
+    tagIds:
+      row.tag_names != null ? row.tag_names.split(TAG_NAME_SEPARATOR) : [],
+  };
+}

--- a/api/src/contexts/search/infrastructure/mappers/search-row.schema.ts
+++ b/api/src/contexts/search/infrastructure/mappers/search-row.schema.ts
@@ -48,6 +48,39 @@ export function isSearchRow(data: unknown): data is SearchRow {
 }
 
 /**
+ * D1クエリ結果の複数行を検証し、有効な行（zodのtransform適用済み）と
+ * 不正な形式で破棄された生の行を振り分ける
+ *
+ * `isSearchRow` は型ガード（真偽値のみ返す）のため、`filter(isSearchRow)`
+ * では TypeScript の型は `SearchRow[]` に絞り込まれるが、実行時の値は
+ * D1が返した生オブジェクトのままで、`d1IdSchema` の `transform(String)` が
+ * 適用されない（数値IDが数値のまま残る）バグを踏みやすい。
+ * この関数は `safeParse` の `.data`（変換後の値）を1回のパースで確実に
+ * 使うことで、型と実行時の値を一致させる。
+ *
+ * @param rows - D1クエリ結果の生の行配列
+ * @returns 検証・変換済みの行と、破棄された生の行
+ */
+export function parseSearchRows(rows: unknown[]): {
+  validRows: SearchRow[];
+  invalidRows: unknown[];
+} {
+  const validRows: SearchRow[] = [];
+  const invalidRows: unknown[] = [];
+
+  for (const row of rows) {
+    const parsed = searchRowSchema.safeParse(row);
+    if (parsed.success) {
+      validRows.push(parsed.data);
+    } else {
+      invalidRows.push(row);
+    }
+  }
+
+  return { validRows, invalidRows };
+}
+
+/**
  * 検索件数クエリ（COUNT(*)）の結果行スキーマ
  */
 export const searchCountRowSchema = z.object({

--- a/api/src/contexts/search/infrastructure/repositories/D1SearchRepository.spec.ts
+++ b/api/src/contexts/search/infrastructure/repositories/D1SearchRepository.spec.ts
@@ -1,0 +1,306 @@
+import { describe, expect, test } from "vitest";
+import { SearchQuizzesQuery } from "../../domain/entities/SearchQuizzesQuery";
+import { D1SearchRepository } from "./D1SearchRepository";
+
+/**
+ * D1Database のテスト用フェイク
+ *
+ * `QuizRepositoryFactory.test.ts` の `DB: {} as D1Database` と同様に、
+ * D1Database はCloudflare Workersのアンビエント型でありテストダブルの
+ * 構造的実装が困難なため、テストヘルパー内でのみ `as D1Database` を使う。
+ *
+ * countQuery（.first()）とdataQuery（.all()）を発行順に振り分けるのではなく、
+ * SQLテキストに "COUNT(*)" を含むかどうかで判定する
+ * （D1SearchRepositoryはPromise.allで両クエリを並行実行するため、
+ * 発行順序に依存したテストダブルは書けない）。
+ */
+function createFakeD1Database(options: {
+  countResult?: unknown;
+  dataResults?: unknown[];
+  countError?: Error;
+  dataError?: Error;
+  onPrepare?: (sql: string, params: unknown[]) => void;
+}): D1Database {
+  const fakeDb = {
+    prepare(sql: string) {
+      let boundParams: unknown[] = [];
+      const statement = {
+        bind(...params: unknown[]) {
+          boundParams = params;
+          return statement;
+        },
+        async first() {
+          options.onPrepare?.(sql, boundParams);
+          if (options.countError) {
+            throw options.countError;
+          }
+          return options.countResult ?? null;
+        },
+        async all() {
+          options.onPrepare?.(sql, boundParams);
+          if (options.dataError) {
+            throw options.dataError;
+          }
+          return {
+            results: options.dataResults ?? [],
+            success: true,
+            meta: {},
+          };
+        },
+      };
+      return statement;
+    },
+  };
+
+  return fakeDb as D1Database;
+}
+
+const createValidRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "1",
+  question: "TypeScriptはJavaScriptのスーパーセットである",
+  answer_type: "boolean",
+  solution_id: "1",
+  explanation: null,
+  status: "approved",
+  creator_id: "1",
+  created_at: "2024-01-15T00:00:00Z",
+  approved_at: null,
+  tag_names: null,
+  ...overrides,
+});
+
+describe("D1SearchRepository", () => {
+  describe("constructor", () => {
+    test("dbが未定義の場合はエラーをthrowする", () => {
+      // D1QuizRepositoryと同じ方針: コンストラクタでの必須依存チェックは
+      // まだResultコンテキストに入る前なのでthrowで表現する
+      expect(
+        () => new D1SearchRepository(undefined as unknown as D1Database),
+      ).toThrow();
+    });
+  });
+
+  describe("searchQuizzes", () => {
+    test("正常系: countとdataの両方が成功した場合、QuizSummaryListResponse形状で返す", async () => {
+      // Arrange
+      const db = createFakeD1Database({
+        countResult: { total: 1 },
+        dataResults: [
+          createValidRow({ tag_names: "プログラミング\x1fWeb開発" }),
+        ],
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery("TypeScript");
+
+      // Act
+      const result = await repository.searchQuizzes(query);
+
+      // Assert
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.totalCount).toBe(1);
+        expect(result.value.hasMore).toBe(false);
+        expect(result.value.items).toHaveLength(1);
+        expect(result.value.items[0]).toEqual({
+          id: "1",
+          question: "TypeScriptはJavaScriptのスーパーセットである",
+          answerType: "boolean",
+          solutionId: "1",
+          status: "approved",
+          creatorId: "1",
+          createdAt: "2024-01-15T00:00:00Z",
+          tagIds: ["プログラミング", "Web開発"],
+        });
+      }
+    });
+
+    test("hasMoreはoffset+limit<totalCountで判定される", async () => {
+      // Arrange
+      const db = createFakeD1Database({
+        countResult: { total: 25 },
+        dataResults: Array.from({ length: 20 }, (_, i) =>
+          createValidRow({ id: String(i + 1) }),
+        ),
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "relevance",
+        "asc",
+        20,
+        0,
+      );
+
+      // Act
+      const result = await repository.searchQuizzes(query);
+
+      // Assert
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.hasMore).toBe(true);
+      }
+    });
+
+    test("結果0件の場合は空配列とtotalCount=0を返す（正常系）", async () => {
+      // Arrange
+      const db = createFakeD1Database({
+        countResult: { total: 0 },
+        dataResults: [],
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery("存在しないキーワード");
+
+      // Act
+      const result = await repository.searchQuizzes(query);
+
+      // Assert
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.items).toEqual([]);
+        expect(result.value.totalCount).toBe(0);
+        expect(result.value.hasMore).toBe(false);
+      }
+    });
+
+    test("不正な形式の行はスキップされ、有効な行のみ返す（quiz-managementのD1QuizSummaryMapperと同じ方針）", async () => {
+      // Arrange
+      const db = createFakeD1Database({
+        countResult: { total: 2 },
+        dataResults: [
+          createValidRow({ id: "1" }),
+          { id: "2" /* question等の必須フィールド欠落 */ },
+        ],
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      const result = await repository.searchQuizzes(query);
+
+      // Assert
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.items).toHaveLength(1);
+        expect(result.value.items[0]?.id).toBe("1");
+      }
+    });
+
+    test("countクエリがD1例外を投げた場合、SEARCH_EXECUTION_FAILEDを返す", async () => {
+      // Arrange
+      const db = createFakeD1Database({
+        countError: new Error("D1_ERROR: connection lost"),
+        dataResults: [createValidRow()],
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      const result = await repository.searchQuizzes(query);
+
+      // Assert
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.type).toBe("SEARCH_EXECUTION_FAILED");
+      }
+    });
+
+    test("dataクエリがD1例外を投げた場合、SEARCH_EXECUTION_FAILEDを返す", async () => {
+      // Arrange
+      const db = createFakeD1Database({
+        countResult: { total: 1 },
+        dataError: new Error("D1_ERROR: query timeout"),
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      const result = await repository.searchQuizzes(query);
+
+      // Assert
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.type).toBe("SEARCH_EXECUTION_FAILED");
+      }
+    });
+
+    test("count結果が不正な形式の場合、SEARCH_EXECUTION_FAILEDを返す", async () => {
+      // Arrange
+      const db = createFakeD1Database({
+        countResult: { unexpected: "shape" },
+        dataResults: [],
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      const result = await repository.searchQuizzes(query);
+
+      // Assert
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.type).toBe("SEARCH_EXECUTION_FAILED");
+      }
+    });
+
+    test("countとdataクエリは同じWHERE条件のパラメータを使って発行される", async () => {
+      // Arrange
+      const preparedCalls: Array<{ sql: string; params: unknown[] }> = [];
+      const db = createFakeD1Database({
+        countResult: { total: 0 },
+        dataResults: [],
+        onPrepare: (sql, params) => {
+          preparedCalls.push({ sql, params });
+        },
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery("React", ["フロントエンド"]);
+
+      // Act
+      await repository.searchQuizzes(query);
+
+      // Assert
+      const countCall = preparedCalls.find((c) => c.sql.includes("COUNT(*)"));
+      const dataCall = preparedCalls.find((c) => !c.sql.includes("COUNT(*)"));
+      expect(countCall?.params).toEqual([
+        "%React%",
+        "%React%",
+        "%React%",
+        "フロントエンド",
+      ]);
+      // dataCallはlimit/offsetが末尾に付与される分だけ長い
+      expect(dataCall?.params).toEqual([
+        "%React%",
+        "%React%",
+        "%React%",
+        "フロントエンド",
+        20,
+        0,
+      ]);
+    });
+  });
+
+  describe("isHealthy", () => {
+    test("SELECT 1 が成功する場合はtrueを返す", async () => {
+      const db = createFakeD1Database({ countResult: { "1": 1 } });
+      const repository = new D1SearchRepository(db);
+      await expect(repository.isHealthy()).resolves.toBe(true);
+    });
+
+    test("D1例外が発生した場合はfalseを返す（例外をthrowしない）", async () => {
+      const db = createFakeD1Database({
+        countError: new Error("D1_ERROR: unavailable"),
+      });
+      const repository = new D1SearchRepository(db);
+      await expect(repository.isHealthy()).resolves.toBe(false);
+    });
+  });
+});

--- a/api/src/contexts/search/infrastructure/repositories/D1SearchRepository.spec.ts
+++ b/api/src/contexts/search/infrastructure/repositories/D1SearchRepository.spec.ts
@@ -1,6 +1,25 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { SearchQuizzesQuery } from "../../domain/entities/SearchQuizzesQuery";
 import { D1SearchRepository } from "./D1SearchRepository";
+
+/**
+ * SQL文中の `?` プレースホルダ数とbind()されたパラメータ数が一致するか検証する
+ *
+ * 実際のD1はプレースホルダ数とパラメータ数が不一致の場合、クエリ実行時
+ * （first()/all()）に `D1_ERROR: too few/many parameter values were provided`
+ * を投げる。SearchQueryBuilderの条件追加時に `conditions.push()` と
+ * `params.push()` の対応が崩れる回帰を、手書きの期待値と独立した形で
+ * 検知するためのガード（手書きのtoEqual期待値自体に同じ誤りが混入すると
+ * 検知できない、という通常のユニットテストの限界を補う）。
+ */
+function assertPlaceholderCountMatches(sql: string, params: unknown[]): void {
+  const placeholderCount = (sql.match(/\?/g) ?? []).length;
+  if (placeholderCount !== params.length) {
+    throw new Error(
+      `D1_ERROR: placeholder count (${placeholderCount}) does not match bound parameter count (${params.length}) for SQL: ${sql}`,
+    );
+  }
+}
 
 /**
  * D1Database のテスト用フェイク
@@ -30,6 +49,7 @@ function createFakeD1Database(options: {
           return statement;
         },
         async first() {
+          assertPlaceholderCountMatches(sql, boundParams);
           options.onPrepare?.(sql, boundParams);
           if (options.countError) {
             throw options.countError;
@@ -37,6 +57,7 @@ function createFakeD1Database(options: {
           return options.countResult ?? null;
         },
         async all() {
+          assertPlaceholderCountMatches(sql, boundParams);
           options.onPrepare?.(sql, boundParams);
           if (options.dataError) {
             throw options.dataError;
@@ -55,14 +76,22 @@ function createFakeD1Database(options: {
   return fakeDb as D1Database;
 }
 
+/**
+ * 実際のD1が返す行の形（id/solution_id/creator_idは数値）を模したフィクスチャ
+ *
+ * ここを文字列（"1"）にしてしまうと、zodのtransform(String)を経由せずとも
+ * 期待値と偶然一致してしまい、「型ガードで narrowing しても実行時の値は
+ * 変換されない」というクラスのバグ（例: id が number のままレスポンスに
+ * 漏れる）をテストが検知できなくなる。
+ */
 const createValidRow = (overrides: Record<string, unknown> = {}) => ({
-  id: "1",
+  id: 1,
   question: "TypeScriptはJavaScriptのスーパーセットである",
   answer_type: "boolean",
-  solution_id: "1",
+  solution_id: 1,
   explanation: null,
   status: "approved",
-  creator_id: "1",
+  creator_id: 1,
   created_at: "2024-01-15T00:00:00Z",
   approved_at: null,
   tag_names: null,
@@ -114,12 +143,61 @@ describe("D1SearchRepository", () => {
       }
     });
 
+    test("D1が数値IDを返しても、id/solutionId/creatorIdは文字列として返る（TypeSpecのQuizId等はstring型のため）", async () => {
+      // Arrange
+      // 型ガード(isSearchRow等)でnarrowingしても、zodのtransformが適用された
+      // 値でなければ実行時にはD1の生の数値がそのまま漏れ出るバグの回帰テスト
+      const db = createFakeD1Database({
+        countResult: { total: 1 },
+        dataResults: [
+          createValidRow({ id: 42, solution_id: 7, creator_id: 3 }),
+        ],
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      const result = await repository.searchQuizzes(query);
+
+      // Assert
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const item = result.value.items[0];
+        expect(item?.id).toBe("42");
+        expect(item?.solutionId).toBe("7");
+        expect(item?.creatorId).toBe("3");
+        expect(typeof item?.id).toBe("string");
+        expect(typeof item?.solutionId).toBe("string");
+        expect(typeof item?.creatorId).toBe("string");
+      }
+    });
+
+    test("D1が件数を文字列で返しても、totalCountは数値として返る", async () => {
+      // Arrange（COUNT(*)の結果はDBドライバによっては文字列で返ることがある）
+      const db = createFakeD1Database({
+        countResult: { total: "5" },
+        dataResults: [],
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      const result = await repository.searchQuizzes(query);
+
+      // Assert
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.totalCount).toBe(5);
+        expect(typeof result.value.totalCount).toBe("number");
+      }
+    });
+
     test("hasMoreはoffset+limit<totalCountで判定される", async () => {
       // Arrange
       const db = createFakeD1Database({
         countResult: { total: 25 },
         dataResults: Array.from({ length: 20 }, (_, i) =>
-          createValidRow({ id: String(i + 1) }),
+          createValidRow({ id: i + 1 }),
         ),
       });
       const repository = new D1SearchRepository(db);
@@ -176,7 +254,7 @@ describe("D1SearchRepository", () => {
       const db = createFakeD1Database({
         countResult: { total: 2 },
         dataResults: [
-          createValidRow({ id: "1" }),
+          createValidRow(),
           { id: "2" /* question等の必須フィールド欠落 */ },
         ],
       });
@@ -191,7 +269,37 @@ describe("D1SearchRepository", () => {
       if (result.isOk()) {
         expect(result.value.items).toHaveLength(1);
         expect(result.value.items[0]?.id).toBe("1");
+        // 既知の制約: totalCountは別クエリ由来のため、行が破棄されると
+        // items.length との乖離が起きうる（D1QuizRepositoryと同じ制約）
+        expect(result.value.totalCount).toBe(2);
       }
+    });
+
+    test("不正な形式の行が破棄された場合、診断用にconsole.errorへ出力される", async () => {
+      // Arrange
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      const db = createFakeD1Database({
+        countResult: { total: 2 },
+        dataResults: [
+          createValidRow(),
+          { id: "2" /* question等の必須フィールド欠落 */ },
+        ],
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      await repository.searchQuizzes(query);
+
+      // Assert
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Dropped invalid search rows:",
+        expect.arrayContaining([expect.objectContaining({ id: "2" })]),
+      );
+
+      consoleErrorSpy.mockRestore();
     });
 
     test("countクエリがD1例外を投げた場合、SEARCH_EXECUTION_FAILEDを返す", async () => {
@@ -229,6 +337,30 @@ describe("D1SearchRepository", () => {
       expect(result.isErr()).toBe(true);
       if (result.isErr()) {
         expect(result.error.type).toBe("SEARCH_EXECUTION_FAILED");
+      }
+    });
+
+    test("countとdataクエリが異なる原因で同時に失敗した場合、両方のメッセージが結果に残る", async () => {
+      // Arrange
+      // neverthrowのResultAsync.combineは最初に見つかったエラーしか
+      // 返さず他方を握りつぶすため、combineWithAllErrorsで両方保持する
+      // ことを検証する（同時障害時に片方の原因が完全に消える回帰を防ぐ）
+      const db = createFakeD1Database({
+        countError: new Error("D1_ERROR: count query - statement too complex"),
+        dataError: new Error("D1_ERROR: data query - resource limit exceeded"),
+      });
+      const repository = new D1SearchRepository(db);
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      const result = await repository.searchQuizzes(query);
+
+      // Assert
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.type).toBe("SEARCH_EXECUTION_FAILED");
+        expect(result.error.message).toContain("検索件数の取得に失敗しました");
+        expect(result.error.message).toContain("検索結果の取得に失敗しました");
       }
     });
 
@@ -301,6 +433,27 @@ describe("D1SearchRepository", () => {
       });
       const repository = new D1SearchRepository(db);
       await expect(repository.isHealthy()).resolves.toBe(false);
+    });
+
+    test("D1例外が発生した場合、診断のためconsole.errorに元エラーが出力される", async () => {
+      // Arrange
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      const dbError = new Error("D1_ERROR: authentication failed");
+      const db = createFakeD1Database({ countError: dbError });
+      const repository = new D1SearchRepository(db);
+
+      // Act
+      await repository.isHealthy();
+
+      // Assert
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "D1SearchRepository health check failed:",
+        dbError,
+      );
+
+      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/api/src/contexts/search/infrastructure/repositories/D1SearchRepository.ts
+++ b/api/src/contexts/search/infrastructure/repositories/D1SearchRepository.ts
@@ -1,0 +1,124 @@
+import type { Result } from "neverthrow";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
+import type { SearchQuizzesQuery } from "../../domain/entities/SearchQuizzesQuery";
+import type {
+  ISearchRepository,
+  SearchError,
+  SearchResult,
+} from "../../domain/repositories/ISearchRepository";
+import {
+  isSearchCountRow,
+  isSearchRow,
+  toQuizSummary,
+} from "../mappers/search-row.schema";
+import {
+  buildSearchCountQuery,
+  buildSearchDataQuery,
+} from "./SearchQueryBuilder";
+
+/**
+ * D1例外を SearchError へ変換する
+ */
+function toSearchExecutionFailedError(
+  error: unknown,
+  message: string,
+): SearchError {
+  return {
+    type: "SEARCH_EXECUTION_FAILED",
+    message,
+    details: error,
+  };
+}
+
+/**
+ * Cloudflare D1データベースを使用した検索リポジトリ実装
+ *
+ * LIKE検索によるクイズ全文検索・タグ絞り込みをD1に対して実行する。
+ * FTS5を採用しない理由は
+ * `docs/project/adr/0027-search-full-text-strategy.md` を参照。
+ */
+export class D1SearchRepository implements ISearchRepository {
+  constructor(private readonly db: D1Database) {
+    if (!db) {
+      throw new Error("D1Database is required for D1SearchRepository");
+    }
+  }
+
+  /**
+   * クイズを検索する
+   *
+   * @param query - 検索クエリエンティティ
+   * @returns 検索結果または検索エラー
+   */
+  async searchQuizzes(
+    query: SearchQuizzesQuery,
+  ): Promise<Result<SearchResult, SearchError>> {
+    return this.executeSearch(query);
+  }
+
+  /**
+   * 検索リポジトリのヘルスチェック
+   *
+   * @returns D1への疎通が正常な場合はtrue
+   */
+  async isHealthy(): Promise<boolean> {
+    return ResultAsync.fromPromise(
+      this.db.prepare("SELECT 1").first(),
+      (error) => error,
+    ).match(
+      () => true,
+      () => false,
+    );
+  }
+
+  /**
+   * 件数取得・データ取得の2クエリを並行実行し、結果を組み立てる
+   */
+  private executeSearch(
+    query: SearchQuizzesQuery,
+  ): ResultAsync<SearchResult, SearchError> {
+    const { sql: countSql, params: countParams } = buildSearchCountQuery(query);
+    const { sql: dataSql, params: dataParams } = buildSearchDataQuery(query);
+
+    const countQuery = ResultAsync.fromPromise(
+      this.db
+        .prepare(countSql)
+        .bind(...countParams)
+        .first(),
+      (error) =>
+        toSearchExecutionFailedError(error, "検索件数の取得に失敗しました"),
+    );
+
+    const dataQuery = ResultAsync.fromPromise(
+      this.db
+        .prepare(dataSql)
+        .bind(...dataParams)
+        .all(),
+      (error) =>
+        toSearchExecutionFailedError(error, "検索結果の取得に失敗しました"),
+    );
+
+    return ResultAsync.combine([countQuery, dataQuery]).andThen(
+      ([countResult, dataResult]) => {
+        if (!isSearchCountRow(countResult)) {
+          return errAsync(
+            toSearchExecutionFailedError(
+              countResult,
+              "検索件数の取得結果が不正な形式です",
+            ),
+          );
+        }
+
+        const totalCount = countResult.total;
+        // 不正な形式の行はスキップする（D1QuizSummaryMapperと同じ方針）
+        const items = dataResult.results.filter(isSearchRow).map(toQuizSummary);
+
+        return okAsync({
+          items,
+          totalCount,
+          hasMore: query.offset + query.limit < totalCount,
+        });
+      },
+    );
+  }
+}

--- a/api/src/contexts/search/infrastructure/repositories/D1SearchRepository.ts
+++ b/api/src/contexts/search/infrastructure/repositories/D1SearchRepository.ts
@@ -7,8 +7,8 @@ import type {
   SearchResult,
 } from "../../domain/repositories/ISearchRepository";
 import {
-  isSearchCountRow,
-  isSearchRow,
+  parseSearchRows,
+  searchCountRowSchema,
   toQuizSummary,
 } from "../mappers/search-row.schema";
 import {
@@ -27,6 +27,22 @@ function toSearchExecutionFailedError(
     type: "SEARCH_EXECUTION_FAILED",
     message,
     details: error,
+  };
+}
+
+/**
+ * count/dataクエリが同時に失敗した場合の複数エラーを1つのSearchErrorへ統合する
+ *
+ * `ResultAsync.combine` は最初に見つかったエラーだけを返し、他方のエラーを
+ * 破棄してしまう（neverthrowの仕様）。両クエリが異なる原因で同時に失敗した
+ * 場合に片方の原因が完全に失われるのを防ぐため、`combineWithAllErrors` で
+ * 収集した全エラーをここで1つにまとめる。
+ */
+function mergeSearchErrors(errors: SearchError[]): SearchError {
+  return {
+    type: "SEARCH_EXECUTION_FAILED",
+    message: errors.map((error) => error.message).join(" / "),
+    details: errors.map((error) => error.details),
   };
 }
 
@@ -53,7 +69,10 @@ export class D1SearchRepository implements ISearchRepository {
   async searchQuizzes(
     query: SearchQuizzesQuery,
   ): Promise<Result<SearchResult, SearchError>> {
-    return this.executeSearch(query);
+    return this.executeSearch(query).mapErr((error) => {
+      console.error("Failed to search quizzes:", error);
+      return error;
+    });
   }
 
   /**
@@ -67,7 +86,10 @@ export class D1SearchRepository implements ISearchRepository {
       (error) => error,
     ).match(
       () => true,
-      () => false,
+      (error) => {
+        console.error("D1SearchRepository health check failed:", error);
+        return false;
+      },
     );
   }
 
@@ -98,9 +120,15 @@ export class D1SearchRepository implements ISearchRepository {
         toSearchExecutionFailedError(error, "検索結果の取得に失敗しました"),
     );
 
-    return ResultAsync.combine([countQuery, dataQuery]).andThen(
-      ([countResult, dataResult]) => {
-        if (!isSearchCountRow(countResult)) {
+    return ResultAsync.combineWithAllErrors([countQuery, dataQuery])
+      .mapErr(mergeSearchErrors)
+      .andThen(([countResult, dataResult]) => {
+        // safeParse().data（zodのtransform適用済みの値）を直接使う。
+        // `isSearchCountRow` のような真偽値のみを返す型ガードで
+        // narrowing しても実行時の値はtransform前の生データのままであり、
+        // total が文字列で返るケースを取りこぼすため使わない。
+        const parsedCount = searchCountRowSchema.safeParse(countResult);
+        if (!parsedCount.success) {
           return errAsync(
             toSearchExecutionFailedError(
               countResult,
@@ -109,16 +137,22 @@ export class D1SearchRepository implements ISearchRepository {
           );
         }
 
-        const totalCount = countResult.total;
-        // 不正な形式の行はスキップする（D1QuizSummaryMapperと同じ方針）
-        const items = dataResult.results.filter(isSearchRow).map(toQuizSummary);
+        const totalCount = parsedCount.data.total;
+        // 不正な形式の行はスキップする（D1QuizRepository.executeFindManyと
+        // 同じ方針）。totalCountは別クエリ由来のため、行が破棄された場合
+        // items.length と totalCount が乖離しうる（既知の制約。
+        // D1QuizRepository側にも同じ制約がある）。診断のためログに残す。
+        const { validRows, invalidRows } = parseSearchRows(dataResult.results);
+        if (invalidRows.length > 0) {
+          console.error("Dropped invalid search rows:", invalidRows);
+        }
+        const items = validRows.map(toQuizSummary);
 
         return okAsync({
           items,
           totalCount,
           hasMore: query.offset + query.limit < totalCount,
         });
-      },
-    );
+      });
   }
 }

--- a/api/src/contexts/search/infrastructure/repositories/SearchQueryBuilder.spec.ts
+++ b/api/src/contexts/search/infrastructure/repositories/SearchQueryBuilder.spec.ts
@@ -1,0 +1,347 @@
+import { describe, expect, test } from "vitest";
+import { SearchQuizzesQuery } from "../../domain/entities/SearchQuizzesQuery";
+import {
+  buildSearchCountQuery,
+  buildSearchDataQuery,
+  buildWhereClause,
+  escapeLikePattern,
+} from "./SearchQueryBuilder";
+
+describe("SearchQueryBuilder", () => {
+  describe("escapeLikePattern", () => {
+    test.each([
+      ["通常の文字列はそのまま返す", "TypeScript", "TypeScript"],
+      ["% はエスケープされる", "100%", "100\\%"],
+      ["_ はエスケープされる", "a_b", "a\\_b"],
+      ["\\ はエスケープされる", "a\\b", "a\\\\b"],
+      [
+        "複数のワイルドカード文字が混在しても全てエスケープされる",
+        "50%_off\\now",
+        "50\\%\\_off\\\\now",
+      ],
+      ["空文字はそのまま返す", "", ""],
+    ])("%s: %s -> %s", (_description, input, expected) => {
+      expect(escapeLikePattern(input)).toBe(expected);
+    });
+
+    test("バックスラッシュを最初に変換するため、エスケープ後の文字が二重にエスケープされない", () => {
+      // "\%" という入力は "\\" + "%" として個別にエスケープされるべきで、
+      // 変換順序を誤ると "\\%" の "%" が誤ってエスケープされる等の不具合が起きる
+      expect(escapeLikePattern("\\%")).toBe("\\\\\\%");
+    });
+  });
+
+  describe("buildWhereClause", () => {
+    test("フィルタ条件が無い場合はWHERE句が空文字になる", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      const { clause, params } = buildWhereClause(query);
+
+      // Assert
+      expect(clause).toBe("");
+      expect(params).toEqual([]);
+    });
+
+    test("searchTextのみ指定した場合、question/explanation/タグ名をLIKEで横断検索するEXISTS句になる", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery("TypeScript");
+
+      // Act
+      const { clause, params } = buildWhereClause(query);
+
+      // Assert
+      expect(clause).toContain("q.question LIKE ? ESCAPE '\\'");
+      expect(clause).toContain("q.explanation LIKE ? ESCAPE '\\'");
+      expect(clause).toContain("EXISTS");
+      expect(clause).toContain("QuizTag");
+      expect(clause).toContain("t.name LIKE ? ESCAPE '\\'");
+      expect(params).toEqual(["%TypeScript%", "%TypeScript%", "%TypeScript%"]);
+    });
+
+    test("searchTextにLIKEメタ文字が含まれる場合はエスケープしてからパターン化する", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery("100%_off");
+
+      // Act
+      const { params } = buildWhereClause(query);
+
+      // Assert
+      expect(params).toEqual([
+        "%100\\%\\_off%",
+        "%100\\%\\_off%",
+        "%100\\%\\_off%",
+      ]);
+    });
+
+    test("tags（肯定）を指定した場合、タグ名でOR照合するEXISTS句になる", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery(undefined, [
+        "プログラミング",
+        "Web開発",
+      ]);
+
+      // Act
+      const { clause, params } = buildWhereClause(query);
+
+      // Assert
+      expect(clause).toContain("EXISTS");
+      expect(clause).not.toContain("NOT EXISTS");
+      expect(clause).toContain("t.name IN (?, ?)");
+      expect(params).toEqual(["プログラミング", "Web開発"]);
+    });
+
+    test("excludeTagsを指定した場合、NOT EXISTS句になる", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery(undefined, undefined, [
+        "初心者向け",
+      ]);
+
+      // Act
+      const { clause, params } = buildWhereClause(query);
+
+      // Assert
+      expect(clause).toContain("NOT EXISTS");
+      expect(clause).toContain("t.name IN (?)");
+      expect(params).toEqual(["初心者向け"]);
+    });
+
+    test("answerTypeを指定した場合、完全一致条件になる", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "single_choice",
+      );
+
+      // Act
+      const { clause, params } = buildWhereClause(query);
+
+      // Assert
+      expect(clause).toBe("WHERE q.answer_type = ?");
+      expect(params).toEqual(["single_choice"]);
+    });
+
+    test("creatorIdを指定した場合、完全一致条件になる", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "user-1",
+      );
+
+      // Act
+      const { clause, params } = buildWhereClause(query);
+
+      // Assert
+      expect(clause).toBe("WHERE q.creator_id = ?");
+      expect(params).toEqual(["user-1"]);
+    });
+
+    test("createdAfter/createdBeforeを指定した場合、datetime()で正規化した範囲条件になる", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "2024-01-01T00:00:00Z",
+        "2024-12-31T23:59:59Z",
+      );
+
+      // Act
+      const { clause, params } = buildWhereClause(query);
+
+      // Assert
+      expect(clause).toBe(
+        "WHERE q.created_at >= datetime(?) AND q.created_at <= datetime(?)",
+      );
+      expect(params).toEqual(["2024-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]);
+    });
+
+    test("複数条件を組み合わせた場合、AND連結され、パラメータが条件の出現順に並ぶ", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery(
+        "React",
+        ["フロントエンド"],
+        ["初心者向け"],
+        undefined,
+        "single_choice",
+        "user-1",
+      );
+
+      // Act
+      const { clause, params } = buildWhereClause(query);
+
+      // Assert
+      // 各EXISTS/NOT EXISTSサブクエリ内部にも AND (qt.quiz_id = q.id AND t.name ...)
+      // が含まれるため、トップレベルの結合だけを厳密に検証する
+      // （前後の文脈で "AND EXISTS" / "AND NOT EXISTS" / "AND q.xxx" と続くかで判別）
+      expect(clause.startsWith("WHERE (q.question LIKE")).toBe(true);
+      expect(clause).toContain(") AND EXISTS (SELECT 1 FROM QuizTag");
+      expect(clause).toContain(") AND NOT EXISTS (SELECT 1 FROM QuizTag");
+      expect(clause).toContain(") AND q.answer_type = ? AND q.creator_id = ?");
+      expect(params).toEqual([
+        "%React%",
+        "%React%",
+        "%React%",
+        "フロントエンド",
+        "初心者向け",
+        "single_choice",
+        "user-1",
+      ]);
+    });
+  });
+
+  describe("buildSearchDataQuery", () => {
+    test("WHERE句が無い場合でもORDER BY / LIMIT OFFSETは常に付与される", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      const { sql, params } = buildSearchDataQuery(query);
+
+      // Assert
+      // SELECT句のタグ名集約サブクエリは常に独自のWHEREを持つため、
+      // トップレベルのフィルタWHERE句の有無は "FROM Quiz q" 〜 "ORDER BY" の
+      // 間に絞って検証する
+      const afterFromQuiz = sql.split("FROM Quiz q")[1] ?? "";
+      const betweenFromAndOrderBy = afterFromQuiz.split("ORDER BY")[0] ?? "";
+      expect(betweenFromAndOrderBy.trim()).toBe("");
+      expect(sql).toContain("ORDER BY q.created_at ASC, q.id ASC");
+      expect(sql).toContain("LIMIT ? OFFSET ?");
+      expect(params).toEqual([20, 0]);
+    });
+
+    test("sortOrder=descの場合、ORDER BY句が created_at と id の両方でDESCになる", () => {
+      // Arrange（同時刻データのページング決定性のためタイブレークキーも方向を揃える）
+      const query = new SearchQuizzesQuery(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "created_date",
+        "desc",
+      );
+
+      // Act
+      const { sql } = buildSearchDataQuery(query);
+
+      // Assert
+      expect(sql).toContain("ORDER BY q.created_at DESC, q.id DESC");
+    });
+
+    test.each([["relevance"], ["popularity"], ["difficulty"]] as const)(
+      "sortBy=%s はMockと同様にcreated_at順にフォールバックする",
+      (sortBy) => {
+        // Arrange
+        const query = new SearchQuizzesQuery(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          sortBy,
+        );
+
+        // Act
+        const { sql } = buildSearchDataQuery(query);
+
+        // Assert
+        expect(sql).toContain("ORDER BY q.created_at");
+      },
+    );
+
+    test("limit/offsetはWHEREパラメータの後ろに末尾追加される", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery(
+        undefined,
+        ["タグ"],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "created_date",
+        "asc",
+        5,
+        10,
+      );
+
+      // Act
+      const { params } = buildSearchDataQuery(query);
+
+      // Assert
+      expect(params).toEqual(["タグ", 5, 10]);
+    });
+
+    test("SELECT句にISO 8601変換済みcreated_at/approved_atとタグ名集約列を含む", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      const { sql } = buildSearchDataQuery(query);
+
+      // Assert
+      expect(sql).toContain(
+        "strftime('%Y-%m-%dT%H:%M:%SZ', q.created_at) AS created_at",
+      );
+      expect(sql).toContain(
+        "strftime('%Y-%m-%dT%H:%M:%SZ', q.approved_at) AS approved_at",
+      );
+      expect(sql).toContain("char(31)");
+      expect(sql).toContain("AS tag_names");
+    });
+  });
+
+  describe("buildSearchCountQuery", () => {
+    test("buildWhereClauseと同じWHERE句を使ってCOUNT(*)を取得する", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery("React", ["フロントエンド"]);
+
+      // Act
+      const { sql, params } = buildSearchCountQuery(query);
+      const { clause, params: whereParams } = buildWhereClause(query);
+
+      // Assert
+      expect(sql).toBe(`SELECT COUNT(*) as total FROM Quiz q ${clause}`.trim());
+      expect(params).toEqual(whereParams);
+    });
+
+    test("LIMIT/OFFSETを含まない", () => {
+      // Arrange
+      const query = new SearchQuizzesQuery();
+
+      // Act
+      const { sql } = buildSearchCountQuery(query);
+
+      // Assert
+      expect(sql).not.toContain("LIMIT");
+      expect(sql).not.toContain("OFFSET");
+    });
+  });
+});

--- a/api/src/contexts/search/infrastructure/repositories/SearchQueryBuilder.ts
+++ b/api/src/contexts/search/infrastructure/repositories/SearchQueryBuilder.ts
@@ -1,0 +1,173 @@
+import type { SearchQuizzesQuery } from "../../domain/entities/SearchQuizzesQuery";
+
+/**
+ * D1クエリのバインドパラメータ型
+ */
+export type D1QueryParam = string | number | boolean | null;
+
+/**
+ * WHERE句とバインドパラメータの組
+ */
+type WhereClauseResult = {
+  clause: string;
+  params: D1QueryParam[];
+};
+
+/**
+ * SQL文とバインドパラメータの組
+ */
+type BuiltQuery = {
+  sql: string;
+  params: D1QueryParam[];
+};
+
+/**
+ * D1データベース用の検索SQLクエリ構築を責務とする関数群
+ *
+ * D1SearchRepositoryから分離し、SQLクエリ構築ロジックの
+ * 単体テストとメンテナンスを容易にします（D1QueryBuilderと同じ設計方針）。
+ */
+
+/**
+ * LIKEパターン中のワイルドカード文字（% _ \）をエスケープする
+ *
+ * バックスラッシュを最初に変換しないと、後続の % / _ の変換で
+ * 二重エスケープが発生するため、変換順序（\ → % → _）を厳守する。
+ *
+ * @param value - エスケープ対象の生文字列
+ * @returns ESCAPE '\' 句と組み合わせて使うエスケープ済み文字列
+ */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
+/**
+ * 検索条件からWHERE句とバインドパラメータを構築する
+ *
+ * データ取得クエリ・件数取得クエリの両方から共用することで、
+ * 「一覧では該当するのに件数には含まれない」といった不整合を防ぐ。
+ *
+ * @param query - 検索クエリエンティティ
+ * @returns WHERE句（条件が無ければ空文字）とバインドパラメータ
+ */
+export function buildWhereClause(query: SearchQuizzesQuery): WhereClauseResult {
+  const conditions: string[] = [];
+  const params: D1QueryParam[] = [];
+
+  // 全文検索: 問題文・解説・タグ名を横断してLIKE部分一致
+  if (query.searchText) {
+    const pattern = `%${escapeLikePattern(query.searchText)}%`;
+    conditions.push(
+      "(q.question LIKE ? ESCAPE '\\' OR q.explanation LIKE ? ESCAPE '\\' OR EXISTS (SELECT 1 FROM QuizTag qt JOIN Tag t ON t.id = qt.tag_id WHERE qt.quiz_id = q.id AND t.name LIKE ? ESCAPE '\\'))",
+    );
+    params.push(pattern, pattern, pattern);
+  }
+
+  // タグ絞り込み（肯定）: いずれかのタグに一致すればヒット（OR意味論）
+  if (query.tags && query.tags.length > 0) {
+    conditions.push(
+      `EXISTS (SELECT 1 FROM QuizTag qt JOIN Tag t ON t.id = qt.tag_id WHERE qt.quiz_id = q.id AND t.name IN (${query.tags.map(() => "?").join(", ")}))`,
+    );
+    params.push(...query.tags);
+  }
+
+  // タグ絞り込み（否定, `~`プレフィックス由来）
+  if (query.excludeTags && query.excludeTags.length > 0) {
+    conditions.push(
+      `NOT EXISTS (SELECT 1 FROM QuizTag qt JOIN Tag t ON t.id = qt.tag_id WHERE qt.quiz_id = q.id AND t.name IN (${query.excludeTags.map(() => "?").join(", ")}))`,
+    );
+    params.push(...query.excludeTags);
+  }
+
+  if (query.answerType) {
+    conditions.push("q.answer_type = ?");
+    params.push(query.answerType);
+  }
+
+  if (query.creatorId) {
+    conditions.push("q.creator_id = ?");
+    params.push(query.creatorId);
+  }
+
+  // D1の created_at は "YYYY-MM-DD HH:MM:SS" 形式、入力はISO 8601のため
+  // datetime() で正規化してから比較する
+  if (query.createdAfter) {
+    conditions.push("q.created_at >= datetime(?)");
+    params.push(query.createdAfter);
+  }
+
+  if (query.createdBefore) {
+    conditions.push("q.created_at <= datetime(?)");
+    params.push(query.createdBefore);
+  }
+
+  return {
+    clause: conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "",
+    params,
+  };
+}
+
+/**
+ * ソート順序を検証済みリテラルへ変換する
+ *
+ * ユーザー入力をSQLへ直接埋め込まないための許可リスト
+ * （呼び出し元でzodによりenum化済みだが、ここでも二重に担保する）。
+ */
+function resolveSortDirection(sortOrder: "asc" | "desc"): "ASC" | "DESC" {
+  return sortOrder === "desc" ? "DESC" : "ASC";
+}
+
+/**
+ * 検索データ取得用のSQLクエリとバインドパラメータを構築する
+ *
+ * sortBy はMockSearchRepositoryと同様に、現時点では全て created_at に
+ * フォールバックする（relevance/popularity/difficulty を算出するための
+ * 集計データがまだ存在しないため）。
+ *
+ * seedデータは created_at が同一タイムスタンプになり得るため、
+ * ページング結果の決定性を保証する目的で q.id を第2ソートキーに使う。
+ *
+ * @param query - 検索クエリエンティティ
+ * @returns 実行可能なSQL文とバインドパラメータ
+ */
+export function buildSearchDataQuery(query: SearchQuizzesQuery): BuiltQuery {
+  const { clause, params } = buildWhereClause(query);
+  const direction = resolveSortDirection(query.sortOrder);
+
+  const sql = `
+    SELECT
+      q.id, q.question, q.answer_type, q.solution_id, q.explanation, q.status, q.creator_id,
+      strftime('%Y-%m-%dT%H:%M:%SZ', q.created_at) AS created_at,
+      strftime('%Y-%m-%dT%H:%M:%SZ', q.approved_at) AS approved_at,
+      (SELECT group_concat(t.name, char(31))
+         FROM QuizTag qt JOIN Tag t ON t.id = qt.tag_id
+        WHERE qt.quiz_id = q.id) AS tag_names
+    FROM Quiz q
+    ${clause}
+    ORDER BY q.created_at ${direction}, q.id ${direction}
+    LIMIT ? OFFSET ?
+  `;
+
+  return {
+    sql: sql.trim(),
+    params: [...params, query.limit, query.offset],
+  };
+}
+
+/**
+ * 検索件数取得用のSQLクエリとバインドパラメータを構築する
+ *
+ * データ取得クエリと同じWHERE句を使うことで、一覧と件数の不整合を防ぐ。
+ *
+ * @param query - 検索クエリエンティティ
+ * @returns 実行可能なSQL文とバインドパラメータ
+ */
+export function buildSearchCountQuery(query: SearchQuizzesQuery): BuiltQuery {
+  const { clause, params } = buildWhereClause(query);
+  const sql = `SELECT COUNT(*) as total FROM Quiz q ${clause}`;
+
+  return {
+    sql: sql.trim(),
+    params,
+  };
+}

--- a/api/src/contexts/search/presentation/routes/search.routes.ts
+++ b/api/src/contexts/search/presentation/routes/search.routes.ts
@@ -1,16 +1,30 @@
 import { Hono } from "hono";
-import type { AppEnv } from "../../../../shared/types";
+import { createSearchRepository } from "../../../../infrastructure/repositories/SearchRepositoryFactory";
+import type { AppEnv, CloudflareBindings } from "../../../../shared/types";
 import { SearchQuizzesUseCase } from "../../application/use-cases/SearchQuizzesUseCase";
-import { MockSearchRepository } from "../../infrastructure/repositories/MockSearchRepository";
 import { SearchController } from "../controllers/SearchController";
-
-// 依存性注入の設定
-const searchRepository = new MockSearchRepository();
-const searchQuizzesUseCase = new SearchQuizzesUseCase(searchRepository);
-const searchController = new SearchController(searchQuizzesUseCase);
 
 // Search ルーティング
 export const searchRoutes = new Hono<AppEnv>();
 
+/**
+ * 検索コントローラーのファクトリー関数
+ *
+ * 環境に応じて適切なリポジトリ（テスト環境: Mock / 本番: D1）を
+ * 使用してコントローラーを作成する（quiz.routes.tsと同じ方針）。
+ * D1はリクエスト毎の c.env からしか取得できないため、モジュール
+ * トップレベルでの固定DIではなくハンドラー内でファクトリーを呼び出す。
+ *
+ * @param env - Cloudflare Workersのバインディング環境変数
+ * @returns 設定済みのSearchController
+ */
+function createSearchController(env: CloudflareBindings): SearchController {
+  const searchRepository = createSearchRepository(env);
+  const searchQuizzesUseCase = new SearchQuizzesUseCase(searchRepository);
+  return new SearchController(searchQuizzesUseCase);
+}
+
 // Quiz Search endpoint
-searchRoutes.get("/quizzes", (c) => searchController.searchQuizzes(c));
+searchRoutes.get("/quizzes", (c) =>
+  createSearchController(c.env).searchQuizzes(c),
+);

--- a/api/src/infrastructure/repositories/SearchRepositoryFactory.test.ts
+++ b/api/src/infrastructure/repositories/SearchRepositoryFactory.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { D1SearchRepository } from "../../contexts/search/infrastructure/repositories/D1SearchRepository";
+import { MockSearchRepository } from "../../contexts/search/infrastructure/repositories/MockSearchRepository";
+import type { CloudflareBindings } from "../../shared/types";
+import { shouldUseMock } from "./QuizRepositoryFactory";
+import { createSearchRepository } from "./SearchRepositoryFactory";
+
+// QuizRepositoryFactory.test.ts と同じ方針のテストヘルパー
+const createMockEnv = (
+  overrides: Partial<CloudflareBindings> = {},
+): CloudflareBindings => {
+  const baseEnv: CloudflareBindings = {
+    NODE_ENV: "development",
+    DB: {} as D1Database,
+    ASSETS: {} as Fetcher,
+  };
+
+  return { ...baseEnv, ...overrides };
+};
+
+describe("createSearchRepository", () => {
+  // shouldUseMock（QuizRepositoryFactoryからexport済み）を再利用しているため、
+  // 判定結果はQuizRepositoryFactoryのテストケースと完全に一致するはず
+  const repositoryTestCases = [
+    {
+      description: "テスト環境ではMockSearchRepositoryを返す",
+      env: createMockEnv({ NODE_ENV: "test" }),
+      expectedType: MockSearchRepository,
+    },
+    {
+      description: "USE_MOCK_DB=trueの場合MockSearchRepositoryを返す",
+      env: createMockEnv({ NODE_ENV: "production", USE_MOCK_DB: "true" }),
+      expectedType: MockSearchRepository,
+    },
+    {
+      description:
+        "開発環境でUSE_MOCK_DB未設定の場合MockSearchRepositoryを返す",
+      env: createMockEnv({ NODE_ENV: "development" }),
+      expectedType: MockSearchRepository,
+    },
+    {
+      description: "開発環境でUSE_MOCK_DB=falseの場合D1SearchRepositoryを返す",
+      env: createMockEnv({ NODE_ENV: "development", USE_MOCK_DB: "false" }),
+      expectedType: D1SearchRepository,
+    },
+    {
+      description: "本番環境でUSE_MOCK_DB未設定の場合D1SearchRepositoryを返す",
+      env: createMockEnv({ NODE_ENV: "production" }),
+      expectedType: D1SearchRepository,
+    },
+    {
+      description: "本番環境でUSE_MOCK_DB=falseの場合D1SearchRepositoryを返す",
+      env: createMockEnv({ NODE_ENV: "production", USE_MOCK_DB: "false" }),
+      expectedType: D1SearchRepository,
+    },
+  ];
+
+  repositoryTestCases.forEach(({ description, env, expectedType }) => {
+    it(description, () => {
+      const repository = createSearchRepository(env);
+      expect(repository).toBeInstanceOf(expectedType);
+    });
+  });
+});
+
+describe("Integration: shouldUseMock and createSearchRepository consistency", () => {
+  const integrationTestCases = [
+    { NODE_ENV: "test" as const },
+    { NODE_ENV: "test" as const, USE_MOCK_DB: "true" },
+    { NODE_ENV: "test" as const, USE_MOCK_DB: "false" },
+    { NODE_ENV: "development" as const },
+    { NODE_ENV: "development" as const, USE_MOCK_DB: "true" },
+    { NODE_ENV: "development" as const, USE_MOCK_DB: "false" },
+    { NODE_ENV: "production" as const },
+    { NODE_ENV: "production" as const, USE_MOCK_DB: "true" },
+    { NODE_ENV: "production" as const, USE_MOCK_DB: "false" },
+  ];
+
+  integrationTestCases.forEach(({ NODE_ENV, USE_MOCK_DB }) => {
+    it(`NODE_ENV=${NODE_ENV}, USE_MOCK_DB=${USE_MOCK_DB ?? "undefined"}: shouldUseMockとcreateSearchRepositoryの結果が一致する`, () => {
+      const mockEnv = createMockEnv({
+        NODE_ENV,
+        ...(USE_MOCK_DB !== undefined && { USE_MOCK_DB }),
+      });
+      const useMock = shouldUseMock(mockEnv);
+      const repository = createSearchRepository(mockEnv);
+
+      if (useMock) {
+        expect(repository).toBeInstanceOf(MockSearchRepository);
+      } else {
+        expect(repository).toBeInstanceOf(D1SearchRepository);
+      }
+    });
+  });
+});

--- a/api/src/infrastructure/repositories/SearchRepositoryFactory.ts
+++ b/api/src/infrastructure/repositories/SearchRepositoryFactory.ts
@@ -1,0 +1,32 @@
+import type { ISearchRepository } from "../../contexts/search/domain/repositories/ISearchRepository";
+import { D1SearchRepository } from "../../contexts/search/infrastructure/repositories/D1SearchRepository";
+import { MockSearchRepository } from "../../contexts/search/infrastructure/repositories/MockSearchRepository";
+import type { CloudflareBindings } from "../../shared/types";
+import { shouldUseMock } from "./QuizRepositoryFactory";
+
+/**
+ * 検索リポジトリファクトリー
+ *
+ * 環境変数に基づいて適切なリポジトリ実装を返します。
+ * - 開発・テスト環境: MockSearchRepository (フィクスチャーベースのモックデータ)
+ * - 本番環境: D1SearchRepository (Cloudflare D1データベース)
+ *
+ * モック判定は QuizRepositoryFactory の shouldUseMock を再利用する
+ * （NODE_ENV / USE_MOCK_DB によるDI切り替えポリシーはコンテキスト横断の
+ * 関心事であり、判定ロジックを二重に持たないため）。
+ *
+ * @example
+ * ```typescript
+ * // Honoハンドラー内で使用
+ * const repository = createSearchRepository(c.env);
+ * ```
+ */
+export function createSearchRepository(
+  env: CloudflareBindings,
+): ISearchRepository {
+  if (shouldUseMock(env)) {
+    return new MockSearchRepository();
+  }
+
+  return new D1SearchRepository(env.DB);
+}

--- a/api/tests/features/quiz-search.spec.ts
+++ b/api/tests/features/quiz-search.spec.ts
@@ -1,0 +1,53 @@
+import { spec } from "pactum";
+
+// Quiz Search BDD Tests - クイズ検索BDDテスト
+// issue #48: search.routes.ts のDI差し替え（モジュールトップレベル固定 →
+// リクエスト毎のSearchRepositoryFactory呼び出し）がルーティングを壊していないこと
+// を確認する回帰テスト。
+//
+// dev-mock env（D1バインディングなし・USE_MOCK_DB=true）で動作するため、
+// MockSearchRepository 経路のみを検証する。D1 経路の実データ確認は
+// `pnpm dev:d1` での手動確認（PR本文に手順記載）で行う。
+//
+// フィクスチャ: src/shared/fixtures/data/search-quiz-rows.json（3件、
+// 全件 status=approved、タグは全件 "programming" 固定）
+
+describe("Quiz Search - クイズ検索", () => {
+  it("フィルタ無しで全件（3件）を返す", async () => {
+    const response = await spec()
+      .get("/api/search/v1/quizzes")
+      .expectStatus(200);
+
+    expect(response.json.totalCount).toBe(3);
+    expect(response.json.items).toHaveLength(3);
+  });
+
+  it("qパラメータでquestion本文を全文検索できる", async () => {
+    const response = await spec()
+      .get("/api/search/v1/quizzes")
+      .withQueryParams("q", "TypeScript")
+      .expectStatus(200);
+
+    expect(response.json.totalCount).toBe(1);
+    expect(response.json.items[0].id).toBe("quiz-3");
+  });
+
+  it("limit/offsetでページネーションできる", async () => {
+    const response = await spec()
+      .get("/api/search/v1/quizzes")
+      .withQueryParams({ limit: 2, offset: 0 })
+      .expectStatus(200);
+
+    expect(response.json.items).toHaveLength(2);
+    expect(response.json.totalCount).toBe(3);
+    expect(response.json.hasMore).toBe(true);
+  });
+
+  it("不正なクエリパラメータ（limit範囲外）はVALIDATION_ERRORになる", async () => {
+    await spec()
+      .get("/api/search/v1/quizzes")
+      .withQueryParams("limit", "0")
+      .expectStatus(400)
+      .expectJsonLike({ error: "VALIDATION_ERROR" });
+  });
+});

--- a/docs/project/adr/0027-search-full-text-strategy.md
+++ b/docs/project/adr/0027-search-full-text-strategy.md
@@ -1,0 +1,141 @@
+# ADR-0027: Search 本番実装の全文検索方式選定
+
+## Status
+
+Proposed
+
+## Context
+
+### Background
+
+issue #48「api: Search 本番 D1 接続」において、`GET /api/search/v1/quizzes`
+（`SearchQuizzesUseCase` / `SearchController`）のデータ源を、フィクスチャー固定の
+`MockSearchRepository`（3件固定）から Cloudflare D1 を用いた `D1SearchRepository`
+へ差し替える。issue の完了条件に「FTS5 または LIKE 検索（D1のFTSサポート状況に
+応じて選択・ADRに記録）」と明記されており、本ADRはその選定記録である。
+
+検索対象は `Quiz.question` / `Quiz.explanation`（自由記述の日本語文）と
+`Tag.name`（「プログラミング」「Web開発」等の日本語タグ名）で、
+`api/migrations/quiz-db/0001_initial.sql` の CHECK制約・スキーマは変更しない前提。
+
+### Drivers
+
+- **D1のFTS対応状況**: SQLiteベースのD1が実際にFTS5をサポートしているか
+- **日本語検索の実用性**: 本アプリの検索語・タグ名の大半が日本語（2〜4文字程度の
+  短い語が多い: 「数学」「歴史」「英語」等）であり、この特性下でも機能すること
+- **既存挙動との整合**: `MockSearchRepository`（`toLowerCase().includes()` による
+  部分一致）と search-quiz-rows等のテスト・フィクスチャーとの意味論的な連続性
+- **データ規模**: 現状 seed データは21件と小規模
+- **実装・運用コスト**: マイグレーション追加や同期トリガーの保守負荷
+
+## Decision
+
+### Chosen Option
+
+**LIKE '%...%' による部分一致検索を採用する。**
+
+`D1SearchRepository`（`SearchQueryBuilder.ts`）で、`question` / `explanation` /
+タグ名（`QuizTag` 経由で `Tag.name` を `EXISTS` 副問い合わせ）を横断して
+`LIKE ? ESCAPE '\'` により部分一致検索する。ワイルドカード文字（`%` `_` `\`）は
+`escapeLikePattern()` でエスケープしてから `%pattern%` に埋め込む。
+
+選択理由：
+
+1. **日本語（特に短い語）でFTS5が実用にならない**。D1のFTS5は
+   [FTS5 module for full-text search](https://developers.cloudflare.com/d1/sql-api/sql-statements/)
+   としてサポートされているが、既定の `unicode61` トークナイザはCJKを分かち書き
+   できず日本語文が1トークン化してしまう。CJK対応の `trigram` トークナイザは
+   3文字未満のクエリにマッチしないという制約があり
+   （[SQLite Forum: Trigram indexes for SQLite](https://sqlite.org/forum/forumpost/c230760fdf?t=c)）、
+   「数学」「歴史」「英語」のような2文字の検索語・タグ名が中心の本アプリでは
+   致命的に検索漏れが発生する。`Intl.Segmenter` 等でアプリ側トークナイズする
+   事例もあるが（[cloudflare-d1-fts5-japanese-search-api](https://github.com/coji/zenn-content/blob/main/articles/cloudflare-d1-fts5-japanese-search-api.md)）、
+   カスタムトークナイザ拡張はWorkers/D1にロードできず採用不可。
+2. **プロジェクトのDB設計指針が既にLIKEを想定している**。
+   `docs/instructions/shared/workflow/05.01_db-design.md` の想定クエリパターン表に
+   `全文検索 | WHERE content LIKE %?% | 低頻度 | <2s | 全文検索インデックス`
+   とあり、本アプリの全文検索要件は元々LIKEで賄う設計。
+3. **既存Mock実装との意味論的整合**。`MockSearchRepository.searchQuizzes` は
+   `toLowerCase().includes()` による部分一致であり、LIKE方式はこれと最も近い
+   挙動になる（大文字小文字の扱いはASCII範囲でSQLiteのLIKEも既定で無視するため
+   概ね一致する）。
+4. **データ規模に対して十分な性能**。seedは21件。`docs/instructions/shared/
+   workflow/05.01_db-design.md` のインデックス作成判断基準（データサイズが
+   小量の場合は作成しない）に照らしても、現時点でLIKEの全表スキャンによる
+   性能問題は生じない。
+
+### Alternatives Considered
+
+以下の代替案を検討した：
+
+| 選択肢 | メリット | デメリット | 評価 |
+|--------|----------|------------|------|
+| **LIKE '%...%'** | **実装が単純・Mockと意味論が揃う・追加スキーマ不要・プロジェクトのDB設計指針と整合** | **ランキング（関連度スコア）が無い・大規模データではフルスキャンコスト増** | **★★★** |
+| FTS5（trigram） | CJKでも動作する・将来的なランキング（bm25）が使える | 3文字未満のクエリにマッチしない（日本語の主要検索語が多く該当）・仮想テーブル＋同期トリガー＋マイグレーションが必要 | ★ |
+| FTS5（unicode61, 既定） | 標準機能で追加実装が少ない | 日本語文を分かち書きできず実質機能しない | ☆ |
+| FTS5 + カスタムトークナイザ（Intl.Segmenter等） | 日本語の適切なトークナイズが可能 | カスタムトークナイザ拡張はD1/Workersにロード不可のため実装不可能 | 対象外 |
+
+## Consequences
+
+### Positive
+
+- 追加のスキーマ変更・マイグレーション・同期トリガーが不要で、issueのスコープ
+  （D1リポジトリの差し替え）に実装を閉じられる
+- `MockSearchRepository` とほぼ同じ検索結果になり、Mock⇔D1切り替え時の
+  ユーザー体験の差異が小さい
+- LIKEエスケープ（`escapeLikePattern`）はユニットテストで網羅済み
+  （`SearchQueryBuilder.spec.ts`）
+
+### Negative
+
+- 関連度ランキング（`sortBy=relevance`）を意味のある形で実装できない
+  （現状もMock同様 `created_at` にフォールバックしており、この制約を継続する）
+- データ量が増えた場合、LIKEの全表スキャンは線形にコストが増える
+
+### Neutral
+
+- タグ絞り込み（肯定/否定, `~`プレフィックス）は `Tag.name` に対する完全一致
+  （`IN` 句）であり、LIKE方式の対象外（元々FTS5化してもタグ完全一致は
+  変わらない）
+- `status`（承認状態）による絞り込みは本ADRのスコープ外
+  （別issueとして起票予定、issue #48 PR本文に記載）
+
+### Risks and Mitigation
+
+| リスク | 発生確率 | 影響度 | 対策 |
+|--------|----------|--------|------|
+| データ量増加によるLIKE全表スキャンの性能劣化 | 中（将来） | 中 | クイズ件数が数千件規模に達した時点で、`created_at`/`status`等の等値条件へのインデックス追加、および本ADRの見直し（FTS5再検討）をトリガーとする |
+| 日本語FTS5トークナイズ手法（`Intl.Segmenter`等アプリ側トークナイズ）の成熟による再評価機会の逸失 | 低 | 低 | 半期毎のADRレビュー（`00.04_adr-management.md`）で技術動向を再確認する |
+
+## Implementation Notes
+
+### Action Items
+
+- [x] `SearchQueryBuilder.buildWhereClause` でLIKEエスケープを実装・テスト
+- [x] `D1SearchRepository` をLIKE方式で実装
+- [ ] 将来、クイズ件数が数千件規模に達した場合はFTS5（日本語対応
+      トークナイズ手法の成熟状況を踏まえて）再評価する
+
+### Timeline
+
+- **決定日**: 2026-08-13（Proposed、指示者レビュー待ち）
+- **実装開始**: 2026-08-13
+- **完了予定**: issue #48 PRマージ時
+
+## References
+
+- [Cloudflare D1 SQL statements（FTS5サポート）](https://developers.cloudflare.com/d1/sql-api/sql-statements/)
+- [D1 Support for Virtual Tables - Cloudflare Community](https://community.cloudflare.com/t/d1-support-for-virtual-tables/607277)
+- [SQLite Forum: Trigram indexes for SQLite（3文字未満マッチ不可の制約）](https://sqlite.org/forum/forumpost/c230760fdf?t=c)
+- [Cloudflare D1 + FTS5 日本語全文検索の実装例（Intl.Segmenterトークナイズ）](https://github.com/coji/zenn-content/blob/main/articles/cloudflare-d1-fts5-japanese-search-api.md)
+- [docs/instructions/shared/workflow/05.01_db-design.md](../../instructions/shared/workflow/05.01_db-design.md)（全文検索のクエリパターン想定）
+- [ADR-0019: リポジトリパターン採用決定](0019-repository-pattern-adoption.md)
+- [ADR-0007: データベース選定](0007-database.md)
+- issue #48: api: Search 本番 D1 接続
+
+---
+
+**Created**: 2026-08-13
+**Last Updated**: 2026-08-13
+**Authors**: Claude Code（tanacchi の指示に基づく実装）
+**Reviewers**: [@tanacchi](https://github.com/tanacchi)

--- a/docs/project/adr/README.md
+++ b/docs/project/adr/README.md
@@ -32,6 +32,7 @@
 | [0024](0024-accessibility-policy.md) | アクセシビリティ方針（WCAG 2.1 AA目標） | Proposed | 2025-08-11 | WCAG 2.1 レベルAAを目標として確定 |
 | [0025](0025-update-endpoint-http-method-policy.md) | 更新系エンドポイントのHTTPメソッド方針 | Proposed | 2026-08-12 | TypeSpec/Hono実装層でのPATCH/POST判断基準を確定 |
 | [0026](0026-anonymous-user-identification-strategy.md) | 匿名ユーザー識別方式選定 | Proposed | 2026-08-11 | Cookie + UUID v4 + ミドルウェア + 遅延解決採用 |
+| [0027](0027-search-full-text-strategy.md) | Search 本番実装の全文検索方式選定 | Proposed | 2026-08-13 | 日本語短語検索の実用性を優先しLIKE方式を採用（FTS5は不採用） |
 
 ## ステータス定義
 
@@ -67,5 +68,5 @@
 ---
 
 **作成日**: 2025-07-28  
-**最終更新**: 2025-08-11  
+**最終更新**: 2026-08-13  
 **管理者**: [@tanacchi](https://github.com/tanacchi)


### PR DESCRIPTION
## 変更内容

- `D1SearchRepository` を `api/src/contexts/search/infrastructure/repositories/` に実装
  - LIKE検索によるクイズ全文検索（question/explanation/タグ名を横断、`~`除外含む）
  - タグ絞り込み（肯定/否定、`Tag.name` との完全一致）
  - 検索方式の選定理由は ADR-0027（Proposed）に記録
- `SearchQueryBuilder` にSQL組み立てロジックを分離（D1QueryBuilderと同じ設計方針）
- `search-row.schema.ts` にD1行→QuizSummaryのzodマッパーを実装（型アサーション不使用）
- `SearchRepositoryFactory` でDIを追加し、`search.routes.ts` をモジュールトップレベル固定
  DIからリクエスト毎のファクトリー呼び出しへ変更（`quiz.routes.ts` と同じ方針）
- `MockSearchRepository` は変更せずテスト用として維持
- 検索エンドポイントの軽量BDDテスト（`quiz-search.spec.ts`）を追加（DI差し替えの回帰検知用）

## 変更理由

issue #48 の指示に基づき、`GET /api/search/v1/quizzes` のデータ源をフィクスチャー
固定の `MockSearchRepository`（3件固定・タグ全件 `programming` 固定）から実際の
D1データへ差し替えた。

検索方式はissue指定通り「D1のFTSサポート状況に応じて選択・ADRに記録」を実施。
D1はFTS5をサポートするが、日本語（特に「数学」「歴史」等の2文字語）では
trigramトークナイザの3文字未満マッチ不可という制約により実用にならないと判明した
ため、LIKE方式を採用した（詳細はADR-0027参照）。

`ISearchRepository` は元々 `Promise<Result<SearchResult, SearchError>>` を返す
非同期シグネチャだったため、インターフェース変更は不要だった
（quiz-managementの `ResultAsync<T, RepositoryError>` パターンへの統一は、
ADR-0019「ドメイン層の純粋性」の観点からも見送った）。

## セルフレビューで発見・修正した問題

初回実装後、3並列の独立レビューエージェント（code-reviewer / silent-failure-hunter /
pr-test-analyzer）で実 D1（`wrangler dev --env dev`）に対する動作確認込みでレビューし、
以下を発見・修正した。

**[Blocking] `id`/`solutionId`/`creatorId` が数値のまま返っていた（OpenAPI契約違反）**

`dataResult.results.filter(isSearchRow)` は型ガードで TypeScript 上の型こそ
`SearchRow[]` に絞り込むが、実行時の値は zod の `transform(String)` 適用前の
生データ（D1由来の数値）のままだった。既存テストのフィクスチャが最初から
文字列IDだったため検知できていなかった。`parseSearchRows`
（`safeParse().data` を使う関数）に差し替え、フィクスチャも実D1同様の数値IDに
修正して回帰を防止した。実D1で `"id":1` → `"id":"1"` になったことを確認済み。

**エラーハンドリングの改善**

- `isHealthy()`: エラーを握りつぶしログを出さず `false` を返していたため、
  `console.error` で元エラーを記録するよう修正
- count/dataクエリが異なる原因で同時に失敗した場合、`ResultAsync.combine` の
  仕様により最初に見つかったエラーしか返らず片方が消えていた。
  `combineWithAllErrors` に変更し両方のメッセージを保持するよう修正
- 不正な形式で破棄された行を `console.error` で記録するよう追加

**テストの頑健性向上**

フェイク `D1Database` に、SQL文中の `?` 数と `bind()` パラメータ数の一致検証
ガードを追加。手書きの期待値自体に同じ誤りが混入すると検知できない、という
通常のユニットテストの限界を補い、将来のクエリ組み立てバグを早期検知する。

## 確認事項

- [x] `pnpm typecheck` 緑（`any`/`as`/`!` 型アサーション不使用）
- [x] `pnpm lint` 緑
- [x] `pnpm test`（unit 1031件 + BDD 24件）緑
- [x] `pnpm build` 緑
- [x] `wrangler dev --env dev`（実D1）で `q=TypeScript`（全文検索）・
      `tags=初級`（2文字タグの肯定/否定）・`sort=-created_date`＋ページネーション
      （`q.id`タイブレークによる境界の重複/欠落なし）・LIKEメタ文字エスケープ・
      `id`/`solutionId`/`creatorId` が文字列で返ることを実機確認
- [x] `wrangler dev --env dev-mock` でMock（3件固定）に戻ることを確認しDI切り替えを実証

## スコープ外（別issueとして起票を提案）

セルフレビューで新たに見つかったものを含む。

- **[優先度: 高]** `status` フィルタ未実装のため、検索結果に未承認・却下クイズが
  混在する（実D1で確認: 21件中 approved 15 / rejected 4 / pending_approval 2）。
  Mockのフィクスチャが全件approvedだったため、D1差し替えで初めて顕在化した挙動。
  デプロイ前に対応要否を判断すべき
- `tags`/`excludeTags` の個数に上限が無く、大量に渡すと D1 の変数上限
  （`too many SQL variables`）に達しHTTP 500になる（`search-query.schema.ts` は
  タグの文字数のみ検証・個数は未検証）
- `created_after`/`created_before` に不正な日付文字列を渡すと、`datetime()` が
  NULLを返し無言で0件になる（400ではなくHTTP 200）
- `creator_id` はTypeSpecの `@doc` ではUUID想定と書かれているが、実DBは連番の
  数値IDのため、UUID形式で渡すと無言で0件になる（quiz-management側も同型式で
  本PR固有の問題ではないが、`UserId` の実体を確定させドキュメントか実装を揃えるべき）
- `SEARCH_TIMEOUT` エラー型・408ハンドラが定義済みだが実装から一度も構築されず、
  D1のタイムアウトも一律 `SEARCH_EXECUTION_FAILED`(500) になる（本PR以前からの
  未使用コード、今回のD1導入が実装機会だった）
- `q` パラメータに文字数上限が無い
- `status` クエリパラメータ未実装（API カタログには記載あるがTypeSpec/実装に無い）
- `search.tsp` の `...PaginationRequest` に `@query` が付いておらず、生成OpenAPIで
  `limit`/`offset` がrequestBody扱いになっている（実装はクエリ文字列から読んでおり乖離）
- `QuizSummary.tagIds` の意味（名称はID、実体はタグ名）
- `difficulty` / 正答率 / `exclude_ids` の実装（DB設計から必要）
- 検索補助インデックスの追加（現状21件のためLIKE全表スキャンで性能問題なし。
  必要になった際は `api/spec/database.dbml` から正規の生成ルートで追加する方針。ADR-0027参照）
- D1経路の自動テストがCIに存在しない（BDDは `dev-mock` 環境のためMock経路のみ検証。
  今回の `id` 数値化バグはこの構造的弱点が顕在化した実例。
  `@cloudflare/vitest-pool-workers` 等の導入を検討）

Closes #48
