### PR TITLE
api: quiz-learning Deck 管理を4層DDDで実装

### DIFF
--- a/api/spec/models/deck.tsp
+++ b/api/spec/models/deck.tsp
@@ -72,6 +72,13 @@ model CreateDeckFromSearchRequest {
   description?: string;
 }
 
+// Deck部分更新リクエスト（ADR-0025のPATCH方針に準拠、ADR-0027参照）
+model UpdateDeckRequest {
+  name?: string;
+  description?: string;
+  quizIds?: QuizId[];
+}
+
 model StartSessionRequest {
   deckId: DeckId;
   deviceFingerprint: string;
@@ -87,6 +94,7 @@ model UpdateSessionRequest {
   isCompleted?: boolean;
 }
 
-model DeckListResponse extends PaginationResponse<DeckWithQuizzes> {}
+// 一覧では問題本体は含めず軽量なDeckのみ返す（詳細はgetDeckで取得。ADR-0027参照）
+model DeckListResponse extends PaginationResponse<Deck> {}
 
 model SessionListResponse extends PaginationResponse<QuizSessionWithProgress> {}

--- a/api/spec/models/deck.tsp
+++ b/api/spec/models/deck.tsp
@@ -72,7 +72,7 @@ model CreateDeckFromSearchRequest {
   description?: string;
 }
 
-// Deck部分更新リクエスト（ADR-0025のPATCH方針に準拠、ADR-0027参照）
+// Deck部分更新リクエスト（ADR-0025のPATCH方針に準拠、ADR-0028参照）
 model UpdateDeckRequest {
   name?: string;
   description?: string;
@@ -94,7 +94,7 @@ model UpdateSessionRequest {
   isCompleted?: boolean;
 }
 
-// 一覧では問題本体は含めず軽量なDeckのみ返す（詳細はgetDeckで取得。ADR-0027参照）
+// 一覧では問題本体は含めず軽量なDeckのみ返す（詳細はgetDeckで取得。ADR-0028参照）
 model DeckListResponse extends PaginationResponse<Deck> {}
 
 model SessionListResponse extends PaginationResponse<QuizSessionWithProgress> {}

--- a/api/spec/operations/quiz-learning.tsp
+++ b/api/spec/operations/quiz-learning.tsp
@@ -51,7 +51,6 @@ interface QuizLearning {
   createDeckFromWrongAnswers(@body request: {
     name?: string;
     description?: string;
-    userId: UserId;
     maxQuizzes?: int32 = 50;
     sinceDays?: int32 = 30;
   }): CreateDeckResponse | ValidationError;
@@ -66,8 +65,12 @@ interface QuizLearning {
   @route("/decks/mine")
   getMyDecks(
     ...PaginationRequest,
-    @query userId: UserId
   ): DeckListResponse;
+
+  /** Update deck (partial update) */
+  @patch(#{ implicitOptionality: false })
+  @route("/decks/{id}")
+  updateDeck(@path id: DeckId, @body request: UpdateDeckRequest): Deck | NotFoundError | ForbiddenError | ValidationError;
 
   /** Delete deck */
   @delete

--- a/api/src/contexts/quiz-learning/application/errors/index.ts
+++ b/api/src/contexts/quiz-learning/application/errors/index.ts
@@ -1,0 +1,9 @@
+export {
+  DeckCreationFailedError,
+  DeckDeletionFailedError,
+  DeckListRetrievalFailedError,
+  DeckRetrievalFailedError,
+  DeckUpdateFailedError,
+  type DeckUseCaseError,
+  UseCaseInternalError,
+} from "./use-case-errors";

--- a/api/src/contexts/quiz-learning/application/errors/use-case-errors.ts
+++ b/api/src/contexts/quiz-learning/application/errors/use-case-errors.ts
@@ -1,0 +1,90 @@
+import { InternalServerError } from "../../../../shared/errors";
+import type { DeckDomainError } from "../../domain/errors";
+
+/**
+ * ユースケース層で発生するエラー
+ */
+
+/**
+ * ユースケース内部エラー
+ */
+export class UseCaseInternalError extends InternalServerError {
+  readonly operation: string;
+
+  constructor(operation: string, details?: string, requestId?: string) {
+    super(`Use case operation failed: ${operation}`, details, requestId);
+    this.operation = operation;
+  }
+}
+
+/**
+ * Deck作成失敗エラー
+ */
+export class DeckCreationFailedError extends InternalServerError {
+  readonly reason: string;
+
+  constructor(reason: string, details?: string, requestId?: string) {
+    super(`Failed to create deck: ${reason}`, details, requestId);
+    this.reason = reason;
+  }
+}
+
+/**
+ * Deck取得失敗エラー
+ */
+export class DeckRetrievalFailedError extends InternalServerError {
+  readonly deckId: string;
+
+  constructor(deckId: string, details?: string, requestId?: string) {
+    super(`Failed to retrieve deck with ID: ${deckId}`, details, requestId);
+    this.deckId = deckId;
+  }
+}
+
+/**
+ * Deck一覧取得失敗エラー
+ */
+export class DeckListRetrievalFailedError extends InternalServerError {
+  readonly creatorId: string;
+
+  constructor(creatorId: string, details?: string, requestId?: string) {
+    super("Failed to retrieve deck list", details, requestId);
+    this.creatorId = creatorId;
+  }
+}
+
+/**
+ * Deck更新失敗エラー
+ */
+export class DeckUpdateFailedError extends InternalServerError {
+  readonly deckId: string;
+
+  constructor(deckId: string, details?: string, requestId?: string) {
+    super(`Failed to update deck with ID: ${deckId}`, details, requestId);
+    this.deckId = deckId;
+  }
+}
+
+/**
+ * Deck削除失敗エラー
+ */
+export class DeckDeletionFailedError extends InternalServerError {
+  readonly deckId: string;
+
+  constructor(deckId: string, details?: string, requestId?: string) {
+    super(`Failed to delete deck with ID: ${deckId}`, details, requestId);
+    this.deckId = deckId;
+  }
+}
+
+/**
+ * ユースケースエラーの統合型
+ */
+export type DeckUseCaseError =
+  | UseCaseInternalError
+  | DeckCreationFailedError
+  | DeckRetrievalFailedError
+  | DeckListRetrievalFailedError
+  | DeckUpdateFailedError
+  | DeckDeletionFailedError
+  | DeckDomainError;

--- a/api/src/contexts/quiz-learning/application/mappers/deck-dto.spec.ts
+++ b/api/src/contexts/quiz-learning/application/mappers/deck-dto.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import { toDeckDto } from "./deck-dto";
+
+describe("toDeckDto", () => {
+  it("descriptionありのDeckを変換する", () => {
+    const deck = Deck.from({
+      id: DeckId.parse("1"),
+      name: "テストDeck",
+      description: "説明文",
+      quizIds: [QuizId.parse("quiz-1")],
+      creatorId: CreatorId.parse("42"),
+      createdAt: "2023-12-01 10:00:00",
+      lastModifiedAt: "2023-12-01 10:00:00",
+    })._unsafeUnwrap();
+
+    const dto = toDeckDto(deck);
+
+    expect(dto).toEqual({
+      id: "1",
+      name: "テストDeck",
+      description: "説明文",
+      quizIds: ["quiz-1"],
+      creatorId: "42",
+      createdAt: "2023-12-01 10:00:00",
+      lastModifiedAt: "2023-12-01 10:00:00",
+    });
+  });
+
+  it("descriptionなしのDeckを変換する（キー自体を含めない）", () => {
+    const deck = Deck.from({
+      id: DeckId.parse("1"),
+      name: "テストDeck",
+      quizIds: [QuizId.parse("quiz-1")],
+      creatorId: CreatorId.parse("42"),
+      createdAt: "2023-12-01 10:00:00",
+      lastModifiedAt: "2023-12-01 10:00:00",
+    })._unsafeUnwrap();
+
+    const dto = toDeckDto(deck);
+
+    expect(dto).not.toHaveProperty("description");
+  });
+});

--- a/api/src/contexts/quiz-learning/application/mappers/deck-dto.ts
+++ b/api/src/contexts/quiz-learning/application/mappers/deck-dto.ts
@@ -1,0 +1,23 @@
+import type { components } from "../../../../shared/types";
+import type { Deck } from "../../domain/entities/deck/Deck";
+
+export type DeckDto = components["schemas"]["Deck"];
+
+/**
+ * DeckエンティティをTypeSpec生成型（`components["schemas"]["Deck"]`）に変換する
+ */
+export function toDeckDto(deck: Deck): DeckDto {
+  const dto: DeckDto = {
+    id: deck.get("id"),
+    name: deck.get("name"),
+    quizIds: deck.get("quizIds"),
+    creatorId: deck.get("creatorId"),
+    createdAt: deck.get("createdAt"),
+    lastModifiedAt: deck.get("lastModifiedAt"),
+  };
+  const description = deck.get("description");
+  if (description !== undefined) {
+    dto.description = description;
+  }
+  return dto;
+}

--- a/api/src/contexts/quiz-learning/application/use-cases/CreateDeckFromSearchUseCase.spec.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/CreateDeckFromSearchUseCase.spec.ts
@@ -1,0 +1,139 @@
+import { ok } from "neverthrow";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createImmediateFailure,
+  createImmediateSuccess,
+} from "../../../../../tests/helpers/mock-helpers";
+import { RepositoryErrorFactory } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import type { SearchQuizzesUseCase } from "../../../search/application/use-cases/SearchQuizzesUseCase";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import { CreateDeckFromSearchUseCase } from "./CreateDeckFromSearchUseCase";
+
+const buildDeck = () =>
+  Deck.from({
+    id: DeckId.parse("1"),
+    name: "検索結果集",
+    quizIds: [QuizId.parse("quiz-1"), QuizId.parse("quiz-2")],
+    creatorId: CreatorId.parse("42"),
+    createdAt: "2023-12-01 10:00:00",
+    lastModifiedAt: "2023-12-01 10:00:00",
+  })._unsafeUnwrap();
+
+describe("CreateDeckFromSearchUseCase", () => {
+  it("検索結果からDeckを生成する", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi.fn().mockReturnValue(createImmediateSuccess(buildDeck())),
+      findById: vi.fn(),
+      findByCreator: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const searchQuizzesUseCase = {
+      execute: vi.fn().mockResolvedValue(
+        ok({
+          items: [
+            { id: "quiz-1", question: "q1" },
+            { id: "quiz-2", question: "q2" },
+          ],
+          totalCount: 2,
+          hasMore: false,
+        }),
+      ),
+    } as unknown as SearchQuizzesUseCase;
+    const useCase = new CreateDeckFromSearchUseCase(
+      deckRepository,
+      identityResolver,
+      searchQuizzesUseCase,
+    );
+
+    const result = await useCase.execute({
+      searchQuery: "JavaScript",
+      maxQuizzes: 50,
+      creatorFingerprint: "some-fingerprint",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(searchQuizzesUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ q: "JavaScript", limit: 50 }),
+    );
+    expect(deckRepository.create).toHaveBeenCalled();
+  });
+
+  it("検索結果が0件の場合はエラーを返す", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi.fn(),
+      findById: vi.fn(),
+      findByCreator: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const searchQuizzesUseCase = {
+      execute: vi
+        .fn()
+        .mockResolvedValue(ok({ items: [], totalCount: 0, hasMore: false })),
+    } as unknown as SearchQuizzesUseCase;
+    const useCase = new CreateDeckFromSearchUseCase(
+      deckRepository,
+      identityResolver,
+      searchQuizzesUseCase,
+    );
+
+    const result = await useCase.execute({
+      searchQuery: "存在しないキーワード",
+      maxQuizzes: 50,
+      creatorFingerprint: "some-fingerprint",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(deckRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("識別子解決に失敗した場合はエラーを返す", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi.fn(),
+      findById: vi.fn(),
+      findByCreator: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi
+        .fn()
+        .mockReturnValue(
+          createImmediateFailure(
+            RepositoryErrorFactory.findFailed("UserIdentity"),
+          ),
+        ),
+    };
+    const searchQuizzesUseCase = {
+      execute: vi.fn(),
+    } as unknown as SearchQuizzesUseCase;
+    const useCase = new CreateDeckFromSearchUseCase(
+      deckRepository,
+      identityResolver,
+      searchQuizzesUseCase,
+    );
+
+    const result = await useCase.execute({
+      searchQuery: "JavaScript",
+      maxQuizzes: 50,
+      creatorFingerprint: "some-fingerprint",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(searchQuizzesUseCase.execute).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/contexts/quiz-learning/application/use-cases/CreateDeckFromSearchUseCase.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/CreateDeckFromSearchUseCase.ts
@@ -1,0 +1,137 @@
+import { errAsync, ok, ResultAsync } from "neverthrow";
+import { CreateFailedError } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import type { components } from "../../../../shared/types";
+import type { SearchQuizzesUseCase } from "../../../search/application/use-cases/SearchQuizzesUseCase";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import {
+  DeckCreationFailedError,
+  type DeckUseCaseError,
+  UseCaseInternalError,
+} from "../errors";
+import { type DeckDto, toDeckDto } from "../mappers/deck-dto";
+
+const DEFAULT_DECK_NAME = "検索結果集";
+
+export type CreateDeckFromSearchCommand = {
+  searchQuery: string;
+  filters?: components["schemas"]["QuizSearchFilters"];
+  maxQuizzes: number;
+  name?: string;
+  description?: string;
+  /** `anonymousSession`ミドルウェアが供給する`c.var.userFingerprint` */
+  creatorFingerprint: string;
+};
+
+/**
+ * 検索結果からDeckを生成するユースケース
+ *
+ * 既存のsearchコンテキストの`SearchQuizzesUseCase`をそのまま注入・
+ * 再利用する（現状Mock実装、issue #48でD1化予定。ADR-0027参照）。
+ */
+export class CreateDeckFromSearchUseCase {
+  constructor(
+    private readonly deckRepository: IDeckRepository,
+    private readonly identityResolver: IUserIdentityResolver,
+    private readonly searchQuizzesUseCase: SearchQuizzesUseCase,
+  ) {}
+
+  execute(
+    command: CreateDeckFromSearchCommand,
+  ): ResultAsync<DeckDto, DeckUseCaseError> {
+    return this.identityResolver
+      .resolve(command.creatorFingerprint)
+      .mapErr(
+        (repositoryError) =>
+          new UseCaseInternalError(
+            "Failed to resolve user identity",
+            repositoryError.message,
+          ),
+      )
+      .andThen((creatorId) =>
+        ResultAsync.fromSafePromise(
+          this.searchQuizzesUseCase.execute({
+            q: command.searchQuery,
+            tags: command.filters?.tags,
+            difficulty: command.filters?.difficulty,
+            answerType: command.filters?.answerType,
+            limit: command.maxQuizzes,
+          }),
+        ).andThen((searchResult) => {
+          if (searchResult.isErr()) {
+            return errAsync<
+              { creatorId: string; quizIds: string[] },
+              DeckUseCaseError
+            >(
+              new UseCaseInternalError(
+                "Failed to search quizzes",
+                JSON.stringify(searchResult.error),
+              ),
+            );
+          }
+
+          const quizIds = searchResult.value.items.map((item) => item.id);
+          if (quizIds.length === 0) {
+            return errAsync<
+              { creatorId: string; quizIds: string[] },
+              DeckUseCaseError
+            >(
+              new DeckCreationFailedError(
+                "no search results found",
+                command.searchQuery,
+              ),
+            );
+          }
+
+          return ResultAsync.fromSafePromise(
+            Promise.resolve({ creatorId, quizIds }),
+          );
+        }),
+      )
+      .andThen(({ creatorId, quizIds }) => {
+        const now = new Date().toISOString().slice(0, 19).replace("T", " ");
+        const deckResult = Deck.from({
+          id: DeckId.parse(Date.now().toString()),
+          name: command.name ?? DEFAULT_DECK_NAME,
+          ...(command.description !== undefined && {
+            description: command.description,
+          }),
+          quizIds: quizIds.map((id) => QuizId.parse(id)),
+          creatorId: CreatorId.parse(creatorId),
+          createdAt: now,
+          lastModifiedAt: now,
+        });
+
+        if (deckResult.isErr()) {
+          return errAsync(
+            new DeckCreationFailedError(
+              "validation failed",
+              deckResult.error.issues.map((issue) => issue.message).join(", "),
+            ),
+          );
+        }
+
+        return this.deckRepository
+          .create(deckResult.value)
+          .mapErr((repositoryError) => {
+            if (repositoryError instanceof CreateFailedError) {
+              return new DeckCreationFailedError(
+                "repository create failed",
+                repositoryError.details,
+              );
+            }
+            return new UseCaseInternalError(
+              "Failed to create deck",
+              repositoryError.message,
+            );
+          });
+      })
+      .andThen((deck) => ok(toDeckDto(deck)));
+  }
+}

--- a/api/src/contexts/quiz-learning/application/use-cases/CreateDeckFromSearchUseCase.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/CreateDeckFromSearchUseCase.ts
@@ -33,7 +33,7 @@ export type CreateDeckFromSearchCommand = {
  * 検索結果からDeckを生成するユースケース
  *
  * 既存のsearchコンテキストの`SearchQuizzesUseCase`をそのまま注入・
- * 再利用する（現状Mock実装、issue #48でD1化予定。ADR-0027参照）。
+ * 再利用する（現状Mock実装、issue #48でD1化予定。ADR-0028参照）。
  */
 export class CreateDeckFromSearchUseCase {
   constructor(

--- a/api/src/contexts/quiz-learning/application/use-cases/CreateDeckFromWrongAnswersUseCase.spec.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/CreateDeckFromWrongAnswersUseCase.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createImmediateFailure,
+  createImmediateSuccess,
+} from "../../../../../tests/helpers/mock-helpers";
+import { RepositoryErrorFactory } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import type { IAttemptQueryRepository } from "../../domain/repositories/IAttemptQueryRepository";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import { CreateDeckFromWrongAnswersUseCase } from "./CreateDeckFromWrongAnswersUseCase";
+
+const buildDeck = () =>
+  Deck.from({
+    id: DeckId.parse("1"),
+    name: "間違い問題集",
+    quizIds: [QuizId.parse("quiz-1"), QuizId.parse("quiz-2")],
+    creatorId: CreatorId.parse("42"),
+    createdAt: "2023-12-01 10:00:00",
+    lastModifiedAt: "2023-12-01 10:00:00",
+  })._unsafeUnwrap();
+
+describe("CreateDeckFromWrongAnswersUseCase", () => {
+  it("間違えた問題からDeckを生成する", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi.fn().mockReturnValue(createImmediateSuccess(buildDeck())),
+      findById: vi.fn(),
+      findByCreator: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const attemptQueryRepository: IAttemptQueryRepository = {
+      findWrongQuizIds: vi
+        .fn()
+        .mockReturnValue(createImmediateSuccess(["quiz-1", "quiz-2"])),
+    };
+    const useCase = new CreateDeckFromWrongAnswersUseCase(
+      deckRepository,
+      identityResolver,
+      attemptQueryRepository,
+    );
+
+    const result = await useCase.execute({
+      creatorFingerprint: "some-fingerprint",
+      maxQuizzes: 50,
+      sinceDays: 30,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(attemptQueryRepository.findWrongQuizIds).toHaveBeenCalledWith("42", {
+      sinceDays: 30,
+      maxQuizzes: 50,
+    });
+    expect(deckRepository.create).toHaveBeenCalled();
+  });
+
+  it("間違えた問題が1件もない場合はエラーを返す", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi.fn(),
+      findById: vi.fn(),
+      findByCreator: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const attemptQueryRepository: IAttemptQueryRepository = {
+      findWrongQuizIds: vi.fn().mockReturnValue(createImmediateSuccess([])),
+    };
+    const useCase = new CreateDeckFromWrongAnswersUseCase(
+      deckRepository,
+      identityResolver,
+      attemptQueryRepository,
+    );
+
+    const result = await useCase.execute({
+      creatorFingerprint: "some-fingerprint",
+      maxQuizzes: 50,
+      sinceDays: 30,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(deckRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("識別子解決に失敗した場合はエラーを返す", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi.fn(),
+      findById: vi.fn(),
+      findByCreator: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi
+        .fn()
+        .mockReturnValue(
+          createImmediateFailure(
+            RepositoryErrorFactory.findFailed("UserIdentity"),
+          ),
+        ),
+    };
+    const attemptQueryRepository: IAttemptQueryRepository = {
+      findWrongQuizIds: vi.fn(),
+    };
+    const useCase = new CreateDeckFromWrongAnswersUseCase(
+      deckRepository,
+      identityResolver,
+      attemptQueryRepository,
+    );
+
+    const result = await useCase.execute({
+      creatorFingerprint: "some-fingerprint",
+      maxQuizzes: 50,
+      sinceDays: 30,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(attemptQueryRepository.findWrongQuizIds).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/contexts/quiz-learning/application/use-cases/CreateDeckFromWrongAnswersUseCase.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/CreateDeckFromWrongAnswersUseCase.ts
@@ -1,0 +1,121 @@
+import { errAsync, ok, type ResultAsync } from "neverthrow";
+import { CreateFailedError } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import type { IAttemptQueryRepository } from "../../domain/repositories/IAttemptQueryRepository";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import {
+  DeckCreationFailedError,
+  type DeckUseCaseError,
+  UseCaseInternalError,
+} from "../errors";
+import { type DeckDto, toDeckDto } from "../mappers/deck-dto";
+
+const DEFAULT_DECK_NAME = "間違い問題集";
+
+export type CreateDeckFromWrongAnswersCommand = {
+  name?: string;
+  description?: string;
+  maxQuizzes: number;
+  sinceDays: number;
+  /** `anonymousSession`ミドルウェアが供給する`c.var.userFingerprint` */
+  creatorFingerprint: string;
+};
+
+/**
+ * 間違い問題からDeckを生成するユースケース
+ *
+ * Session/Answer集約自体は次issueのスコープだが、既存の`Attempt`
+ * テーブルを`IAttemptQueryRepository`経由で読み取り専用参照する
+ * （domain/repositories/IAttemptQueryRepository.ts参照）。
+ */
+export class CreateDeckFromWrongAnswersUseCase {
+  constructor(
+    private readonly deckRepository: IDeckRepository,
+    private readonly identityResolver: IUserIdentityResolver,
+    private readonly attemptQueryRepository: IAttemptQueryRepository,
+  ) {}
+
+  execute(
+    command: CreateDeckFromWrongAnswersCommand,
+  ): ResultAsync<DeckDto, DeckUseCaseError> {
+    return this.identityResolver
+      .resolve(command.creatorFingerprint)
+      .mapErr(
+        (repositoryError) =>
+          new UseCaseInternalError(
+            "Failed to resolve user identity",
+            repositoryError.message,
+          ),
+      )
+      .andThen((creatorId) =>
+        this.attemptQueryRepository
+          .findWrongQuizIds(creatorId, {
+            sinceDays: command.sinceDays,
+            maxQuizzes: command.maxQuizzes,
+          })
+          .mapErr(
+            (repositoryError) =>
+              new UseCaseInternalError(
+                "Failed to find wrong quiz ids",
+                repositoryError.message,
+              ),
+          )
+          .andThen((quizIds) => {
+            if (quizIds.length === 0) {
+              return errAsync(
+                new DeckCreationFailedError(
+                  "no wrong questions found",
+                  `creatorId=${creatorId}, sinceDays=${command.sinceDays}`,
+                ),
+              );
+            }
+
+            const now = new Date().toISOString().slice(0, 19).replace("T", " ");
+            const deckResult = Deck.from({
+              id: DeckId.parse(Date.now().toString()),
+              name: command.name ?? DEFAULT_DECK_NAME,
+              ...(command.description !== undefined && {
+                description: command.description,
+              }),
+              quizIds: quizIds.map((id) => QuizId.parse(id)),
+              creatorId: CreatorId.parse(creatorId),
+              createdAt: now,
+              lastModifiedAt: now,
+            });
+
+            if (deckResult.isErr()) {
+              return errAsync(
+                new DeckCreationFailedError(
+                  "validation failed",
+                  deckResult.error.issues
+                    .map((issue) => issue.message)
+                    .join(", "),
+                ),
+              );
+            }
+
+            return this.deckRepository
+              .create(deckResult.value)
+              .mapErr((repositoryError) => {
+                if (repositoryError instanceof CreateFailedError) {
+                  return new DeckCreationFailedError(
+                    "repository create failed",
+                    repositoryError.details,
+                  );
+                }
+                return new UseCaseInternalError(
+                  "Failed to create deck",
+                  repositoryError.message,
+                );
+              });
+          }),
+      )
+      .andThen((deck) => ok(toDeckDto(deck)));
+  }
+}

--- a/api/src/contexts/quiz-learning/application/use-cases/CreateDeckUseCase.spec.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/CreateDeckUseCase.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createImmediateFailure,
+  createImmediateSuccess,
+} from "../../../../../tests/helpers/mock-helpers";
+import { RepositoryErrorFactory } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import { CreateDeckUseCase } from "./CreateDeckUseCase";
+
+const buildDeck = () =>
+  Deck.from({
+    id: DeckId.parse("1"),
+    name: "テストDeck",
+    quizIds: [QuizId.parse("quiz-1")],
+    creatorId: CreatorId.parse("42"),
+    createdAt: "2023-12-01 10:00:00",
+    lastModifiedAt: "2023-12-01 10:00:00",
+  })._unsafeUnwrap();
+
+describe("CreateDeckUseCase", () => {
+  it("fingerprintを解決しDeckを作成する", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi.fn().mockReturnValue(createImmediateSuccess(buildDeck())),
+      findById: vi.fn(),
+      findByCreator: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const useCase = new CreateDeckUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute({
+      name: "テストDeck",
+      quizIds: ["quiz-1"],
+      creatorFingerprint: "some-fingerprint",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.name).toBe("テストDeck");
+    }
+    expect(identityResolver.resolve).toHaveBeenCalledWith("some-fingerprint");
+    expect(deckRepository.create).toHaveBeenCalled();
+  });
+
+  it("quizIdsが空の場合はエラーを返す", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi.fn(),
+      findById: vi.fn(),
+      findByCreator: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const useCase = new CreateDeckUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute({
+      name: "テストDeck",
+      quizIds: [],
+      creatorFingerprint: "some-fingerprint",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(deckRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("識別子解決に失敗した場合はエラーを返す", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi.fn(),
+      findById: vi.fn(),
+      findByCreator: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi
+        .fn()
+        .mockReturnValue(
+          createImmediateFailure(
+            RepositoryErrorFactory.findFailed("UserIdentity"),
+          ),
+        ),
+    };
+    const useCase = new CreateDeckUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute({
+      name: "テストDeck",
+      quizIds: ["quiz-1"],
+      creatorFingerprint: "some-fingerprint",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(deckRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("リポジトリ作成に失敗した場合はエラーを返す", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi
+        .fn()
+        .mockReturnValue(
+          createImmediateFailure(RepositoryErrorFactory.createFailed("Deck")),
+        ),
+      findById: vi.fn(),
+      findByCreator: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const useCase = new CreateDeckUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute({
+      name: "テストDeck",
+      quizIds: ["quiz-1"],
+      creatorFingerprint: "some-fingerprint",
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/api/src/contexts/quiz-learning/application/use-cases/CreateDeckUseCase.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/CreateDeckUseCase.ts
@@ -1,0 +1,90 @@
+import { errAsync, ok, type ResultAsync } from "neverthrow";
+import { CreateFailedError } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import {
+  DeckCreationFailedError,
+  type DeckUseCaseError,
+  UseCaseInternalError,
+} from "../errors";
+import { type DeckDto, toDeckDto } from "../mappers/deck-dto";
+
+/**
+ * Deck作成コマンド
+ */
+export type CreateDeckCommand = {
+  name?: string;
+  description?: string;
+  quizIds: string[];
+  /** `anonymousSession`ミドルウェアが供給する`c.var.userFingerprint` */
+  creatorFingerprint: string;
+};
+
+/**
+ * Deck新規作成ユースケース（手動選択）
+ */
+export class CreateDeckUseCase {
+  constructor(
+    private readonly deckRepository: IDeckRepository,
+    private readonly identityResolver: IUserIdentityResolver,
+  ) {}
+
+  execute(command: CreateDeckCommand): ResultAsync<DeckDto, DeckUseCaseError> {
+    return this.identityResolver
+      .resolve(command.creatorFingerprint)
+      .mapErr(
+        (repositoryError) =>
+          new UseCaseInternalError(
+            "Failed to resolve user identity",
+            repositoryError.message,
+          ),
+      )
+      .andThen((creatorId) => {
+        const now = new Date().toISOString().slice(0, 19).replace("T", " ");
+        const deckId = Date.now().toString();
+
+        const deckResult = Deck.from({
+          id: DeckId.parse(deckId),
+          name: command.name ?? "無題のDeck",
+          ...(command.description !== undefined && {
+            description: command.description,
+          }),
+          quizIds: command.quizIds.map((id) => QuizId.parse(id)),
+          creatorId: CreatorId.parse(creatorId),
+          createdAt: now,
+          lastModifiedAt: now,
+        });
+
+        if (deckResult.isErr()) {
+          return errAsync(
+            new DeckCreationFailedError(
+              "validation failed",
+              deckResult.error.issues.map((issue) => issue.message).join(", "),
+            ),
+          );
+        }
+
+        return this.deckRepository
+          .create(deckResult.value)
+          .mapErr((repositoryError) => {
+            if (repositoryError instanceof CreateFailedError) {
+              return new DeckCreationFailedError(
+                "repository create failed",
+                repositoryError.details,
+              );
+            }
+            return new UseCaseInternalError(
+              "Failed to create deck",
+              repositoryError.message,
+            );
+          });
+      })
+      .andThen((deck) => ok(toDeckDto(deck)));
+  }
+}

--- a/api/src/contexts/quiz-learning/application/use-cases/DeleteDeckUseCase.spec.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/DeleteDeckUseCase.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createImmediateFailure,
+  createImmediateSuccess,
+} from "../../../../../tests/helpers/mock-helpers";
+import { RepositoryErrorFactory } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import { DeleteDeckUseCase } from "./DeleteDeckUseCase";
+
+const buildDeck = (creatorId = "42") =>
+  Deck.from({
+    id: DeckId.parse("1"),
+    name: "テストDeck",
+    quizIds: [QuizId.parse("quiz-1")],
+    creatorId: CreatorId.parse(creatorId),
+    createdAt: "2023-12-01 10:00:00",
+    lastModifiedAt: "2023-12-01 10:00:00",
+  })._unsafeUnwrap();
+
+const createDeckRepositoryStub = (
+  overrides: Partial<IDeckRepository> = {},
+): IDeckRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findByCreator: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  ...overrides,
+});
+
+describe("DeleteDeckUseCase", () => {
+  it("所有者本人であればDeckを削除できる", async () => {
+    const deckRepository = createDeckRepositoryStub({
+      findById: vi.fn().mockReturnValue(createImmediateSuccess(buildDeck())),
+      delete: vi.fn().mockReturnValue(createImmediateSuccess(undefined)),
+    });
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const useCase = new DeleteDeckUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute("1", "fingerprint-of-42");
+
+    expect(result.isOk()).toBe(true);
+    expect(deckRepository.delete).toHaveBeenCalledWith("1");
+  });
+
+  it("所有者でない場合はForbiddenErrorを返す", async () => {
+    const deckRepository = createDeckRepositoryStub({
+      findById: vi
+        .fn()
+        .mockReturnValue(createImmediateSuccess(buildDeck("42"))),
+    });
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("99")),
+    };
+    const useCase = new DeleteDeckUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute("1", "fingerprint-of-99");
+
+    expect(result.isErr()).toBe(true);
+    expect(deckRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it("Deckが見つからない場合はエラーを返す", async () => {
+    const deckRepository = createDeckRepositoryStub({
+      findById: vi
+        .fn()
+        .mockReturnValue(
+          createImmediateFailure(RepositoryErrorFactory.findFailed("Deck")),
+        ),
+    });
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const useCase = new DeleteDeckUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute("nonexistent", "fingerprint-of-42");
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/api/src/contexts/quiz-learning/application/use-cases/DeleteDeckUseCase.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/DeleteDeckUseCase.ts
@@ -1,0 +1,67 @@
+import { errAsync, ok, type ResultAsync } from "neverthrow";
+import { DeleteFailedError, FindFailedError } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import { DeckForbiddenError, DeckNotFoundError } from "../../domain/errors";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import {
+  DeckDeletionFailedError,
+  type DeckUseCaseError,
+  UseCaseInternalError,
+} from "../errors";
+
+/**
+ * Deck削除ユースケース
+ */
+export class DeleteDeckUseCase {
+  constructor(
+    private readonly deckRepository: IDeckRepository,
+    private readonly identityResolver: IUserIdentityResolver,
+  ) {}
+
+  execute(
+    id: string,
+    creatorFingerprint: string,
+  ): ResultAsync<void, DeckUseCaseError> {
+    return this.identityResolver
+      .resolve(creatorFingerprint)
+      .mapErr(
+        (repositoryError) =>
+          new UseCaseInternalError(
+            "Failed to resolve user identity",
+            repositoryError.message,
+          ),
+      )
+      .andThen((creatorId) =>
+        this.deckRepository
+          .findById(id)
+          .mapErr((repositoryError) => {
+            if (
+              repositoryError instanceof FindFailedError &&
+              repositoryError.details?.toLowerCase().includes("not found")
+            ) {
+              return new DeckNotFoundError(id);
+            }
+            return new UseCaseInternalError(
+              "Failed to get deck",
+              repositoryError.message,
+            );
+          })
+          .andThen((deck) => {
+            if (!deck.isOwnedBy(creatorId)) {
+              return errAsync(new DeckForbiddenError(id));
+            }
+
+            return this.deckRepository.delete(id).mapErr((repositoryError) => {
+              if (repositoryError instanceof DeleteFailedError) {
+                return new DeckDeletionFailedError(id, repositoryError.details);
+              }
+              return new UseCaseInternalError(
+                "Failed to delete deck",
+                repositoryError.message,
+              );
+            });
+          }),
+      )
+      .andThen(() => ok(undefined));
+  }
+}

--- a/api/src/contexts/quiz-learning/application/use-cases/GetDeckUseCase.spec.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/GetDeckUseCase.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createImmediateFailure,
+  createImmediateSuccess,
+} from "../../../../../tests/helpers/mock-helpers";
+import { RepositoryErrorFactory } from "../../../../shared/errors";
+import type { components } from "../../../../shared/types";
+import type { IQuizRepository } from "../../../quiz-management/domain/repositories/IQuizRepository";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import { GetDeckUseCase } from "./GetDeckUseCase";
+
+const buildDeck = () =>
+  Deck.from({
+    id: DeckId.parse("1"),
+    name: "テストDeck",
+    quizIds: [QuizId.parse("quiz-1"), QuizId.parse("quiz-2")],
+    creatorId: CreatorId.parse("42"),
+    createdAt: "2023-12-01 10:00:00",
+    lastModifiedAt: "2023-12-01 10:00:00",
+  })._unsafeUnwrap();
+
+const buildQuizResponse = (id: string): components["schemas"]["QuizResponse"] =>
+  ({
+    id,
+    question: `question-${id}`,
+    answerType: "boolean",
+    solution: { type: "boolean", value: true },
+    status: "approved",
+    creatorId: "42",
+    createdAt: "2023-12-01 10:00:00",
+  }) as components["schemas"]["QuizResponse"];
+
+const createDeckRepositoryStub = (
+  overrides: Partial<IDeckRepository> = {},
+): IDeckRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findByCreator: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  ...overrides,
+});
+
+describe("GetDeckUseCase", () => {
+  it("Deckと紐づくQuizを取得しDeckWithQuizzesを返す", async () => {
+    const deckRepository = createDeckRepositoryStub({
+      findById: vi.fn().mockReturnValue(createImmediateSuccess(buildDeck())),
+    });
+    const quizRepository: IQuizRepository = {
+      create: vi.fn(),
+      findById: vi
+        .fn()
+        .mockImplementation((id: string) =>
+          createImmediateSuccess(buildQuizResponse(id)),
+        ),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const useCase = new GetDeckUseCase(deckRepository, quizRepository);
+
+    const result = await useCase.execute("1");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.quizzes).toHaveLength(2);
+      expect(result.value.totalQuizzes).toBe(2);
+    }
+  });
+
+  it("存在しないQuizIdは結果から除外する（欠損を許容）", async () => {
+    const deckRepository = createDeckRepositoryStub({
+      findById: vi.fn().mockReturnValue(createImmediateSuccess(buildDeck())),
+    });
+    const quizRepository: IQuizRepository = {
+      create: vi.fn(),
+      findById: vi.fn().mockImplementation((id: string) => {
+        if (id === "quiz-1") {
+          return createImmediateSuccess(buildQuizResponse(id));
+        }
+        return createImmediateFailure(
+          RepositoryErrorFactory.findFailed(
+            "Quiz",
+            new Error(`not found: ${id}`),
+          ),
+        );
+      }),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const useCase = new GetDeckUseCase(deckRepository, quizRepository);
+
+    const result = await useCase.execute("1");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.quizzes).toHaveLength(1);
+      expect(result.value.totalQuizzes).toBe(1);
+    }
+  });
+
+  it("Deckが見つからない場合はエラーを返す", async () => {
+    const deckRepository = createDeckRepositoryStub({
+      findById: vi
+        .fn()
+        .mockReturnValue(
+          createImmediateFailure(RepositoryErrorFactory.findFailed("Deck")),
+        ),
+    });
+    const quizRepository: IQuizRepository = {
+      create: vi.fn(),
+      findById: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const useCase = new GetDeckUseCase(deckRepository, quizRepository);
+
+    const result = await useCase.execute("nonexistent");
+
+    expect(result.isErr()).toBe(true);
+    expect(quizRepository.findById).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/contexts/quiz-learning/application/use-cases/GetDeckUseCase.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/GetDeckUseCase.ts
@@ -1,0 +1,73 @@
+import { ok, okAsync, ResultAsync } from "neverthrow";
+import { FindFailedError } from "../../../../shared/errors";
+import type { components } from "../../../../shared/types";
+import type { IQuizRepository } from "../../../quiz-management/domain/repositories/IQuizRepository";
+import { DeckNotFoundError } from "../../domain/errors";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import {
+  DeckRetrievalFailedError,
+  type DeckUseCaseError,
+  UseCaseInternalError,
+} from "../errors";
+import { toDeckDto } from "../mappers/deck-dto";
+
+type DeckWithQuizzesDto = components["schemas"]["DeckWithQuizzes"];
+type QuizResponse = components["schemas"]["QuizResponse"];
+
+/**
+ * Deck詳細取得ユースケース
+ *
+ * quiz-managementのIQuizRepositoryを読み取り専用で参照し、
+ * Deckに紐づく問題本体を解決する（ADR-0027参照：意図的な
+ * コンテキスト間参照）。存在しないQuizIdは結果から除外し、
+ * Deck自体の取得は失敗させない。
+ */
+export class GetDeckUseCase {
+  constructor(
+    private readonly deckRepository: IDeckRepository,
+    private readonly quizRepository: IQuizRepository,
+  ) {}
+
+  execute(id: string): ResultAsync<DeckWithQuizzesDto, DeckUseCaseError> {
+    return this.deckRepository
+      .findById(id)
+      .mapErr((repositoryError) => {
+        if (
+          repositoryError instanceof FindFailedError &&
+          repositoryError.details?.toLowerCase().includes("not found")
+        ) {
+          return new DeckNotFoundError(id);
+        }
+        if (repositoryError instanceof FindFailedError) {
+          return new DeckRetrievalFailedError(id, repositoryError.details);
+        }
+        return new UseCaseInternalError(
+          "Failed to get deck",
+          repositoryError.message,
+        );
+      })
+      .andThen((deck) => {
+        const quizIds = deck.get("quizIds");
+        return ResultAsync.combine(
+          quizIds.map((quizId) =>
+            this.quizRepository
+              .findById(quizId)
+              .map((quiz): QuizResponse | undefined => quiz)
+              .orElse(() =>
+                okAsync<QuizResponse | undefined, never>(undefined),
+              ),
+          ),
+        ).andThen((quizzesOrUndefined) => {
+          const quizzes = quizzesOrUndefined.filter(
+            (quiz): quiz is QuizResponse => quiz !== undefined,
+          );
+          const dto: DeckWithQuizzesDto = {
+            ...toDeckDto(deck),
+            quizzes,
+            totalQuizzes: quizzes.length,
+          };
+          return ok(dto);
+        });
+      });
+  }
+}

--- a/api/src/contexts/quiz-learning/application/use-cases/GetDeckUseCase.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/GetDeckUseCase.ts
@@ -18,7 +18,7 @@ type QuizResponse = components["schemas"]["QuizResponse"];
  * Deck詳細取得ユースケース
  *
  * quiz-managementのIQuizRepositoryを読み取り専用で参照し、
- * Deckに紐づく問題本体を解決する（ADR-0027参照：意図的な
+ * Deckに紐づく問題本体を解決する（ADR-0028参照：意図的な
  * コンテキスト間参照）。存在しないQuizIdは結果から除外し、
  * Deck自体の取得は失敗させない。
  */

--- a/api/src/contexts/quiz-learning/application/use-cases/GetMyDecksUseCase.spec.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/GetMyDecksUseCase.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createImmediateFailure,
+  createImmediateSuccess,
+} from "../../../../../tests/helpers/mock-helpers";
+import { RepositoryErrorFactory } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import { GetMyDecksUseCase } from "./GetMyDecksUseCase";
+
+const buildDeck = (id: string) =>
+  Deck.from({
+    id: DeckId.parse(id),
+    name: `Deck-${id}`,
+    quizIds: [QuizId.parse("quiz-1")],
+    creatorId: CreatorId.parse("42"),
+    createdAt: "2023-12-01 10:00:00",
+    lastModifiedAt: "2023-12-01 10:00:00",
+  })._unsafeUnwrap();
+
+describe("GetMyDecksUseCase", () => {
+  it("fingerprintを解決し自分のDeck一覧を取得する", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi.fn(),
+      findById: vi.fn(),
+      findByCreator: vi.fn().mockReturnValue(
+        createImmediateSuccess({
+          items: [buildDeck("1"), buildDeck("2")],
+          totalCount: 2,
+          hasMore: false,
+        }),
+      ),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const useCase = new GetMyDecksUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute({
+      creatorFingerprint: "some-fingerprint",
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.items).toHaveLength(2);
+      expect(result.value.totalCount).toBe(2);
+      expect(result.value.hasMore).toBe(false);
+    }
+    expect(deckRepository.findByCreator).toHaveBeenCalledWith("42", {
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("識別子解決に失敗した場合はエラーを返す", async () => {
+    const deckRepository: IDeckRepository = {
+      create: vi.fn(),
+      findById: vi.fn(),
+      findByCreator: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi
+        .fn()
+        .mockReturnValue(
+          createImmediateFailure(
+            RepositoryErrorFactory.findFailed("UserIdentity"),
+          ),
+        ),
+    };
+    const useCase = new GetMyDecksUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute({
+      creatorFingerprint: "some-fingerprint",
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(deckRepository.findByCreator).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/contexts/quiz-learning/application/use-cases/GetMyDecksUseCase.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/GetMyDecksUseCase.ts
@@ -23,7 +23,7 @@ export type GetMyDecksQuery = {
  * 自分のDeck一覧取得ユースケース
  *
  * issue #47の「一覧」要件は本ユースケース（`GET /decks/mine`）で満たす
- * （ADR-0027参照）。
+ * （ADR-0028参照）。
  */
 export class GetMyDecksUseCase {
   constructor(

--- a/api/src/contexts/quiz-learning/application/use-cases/GetMyDecksUseCase.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/GetMyDecksUseCase.ts
@@ -1,0 +1,73 @@
+import { ok, type ResultAsync } from "neverthrow";
+import { FindFailedError } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import type { components } from "../../../../shared/types";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import {
+  DeckListRetrievalFailedError,
+  type DeckUseCaseError,
+  UseCaseInternalError,
+} from "../errors";
+import { toDeckDto } from "../mappers/deck-dto";
+
+type DeckListResponseDto = components["schemas"]["DeckListResponse"];
+
+export type GetMyDecksQuery = {
+  /** `anonymousSession`ミドルウェアが供給する`c.var.userFingerprint` */
+  creatorFingerprint: string;
+  limit: number;
+  offset: number;
+};
+
+/**
+ * 自分のDeck一覧取得ユースケース
+ *
+ * issue #47の「一覧」要件は本ユースケース（`GET /decks/mine`）で満たす
+ * （ADR-0027参照）。
+ */
+export class GetMyDecksUseCase {
+  constructor(
+    private readonly deckRepository: IDeckRepository,
+    private readonly identityResolver: IUserIdentityResolver,
+  ) {}
+
+  execute(
+    query: GetMyDecksQuery,
+  ): ResultAsync<DeckListResponseDto, DeckUseCaseError> {
+    return this.identityResolver
+      .resolve(query.creatorFingerprint)
+      .mapErr(
+        (repositoryError) =>
+          new UseCaseInternalError(
+            "Failed to resolve user identity",
+            repositoryError.message,
+          ),
+      )
+      .andThen((creatorId) =>
+        this.deckRepository
+          .findByCreator(creatorId, {
+            limit: query.limit,
+            offset: query.offset,
+          })
+          .mapErr((repositoryError) => {
+            if (repositoryError instanceof FindFailedError) {
+              return new DeckListRetrievalFailedError(
+                creatorId,
+                repositoryError.details,
+              );
+            }
+            return new UseCaseInternalError(
+              "Failed to list decks",
+              repositoryError.message,
+            );
+          }),
+      )
+      .andThen((result) =>
+        ok({
+          items: result.items.map((deck) => toDeckDto(deck)),
+          totalCount: result.totalCount,
+          hasMore: result.hasMore,
+        }),
+      );
+  }
+}

--- a/api/src/contexts/quiz-learning/application/use-cases/UpdateDeckUseCase.spec.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/UpdateDeckUseCase.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createImmediateFailure,
+  createImmediateSuccess,
+} from "../../../../../tests/helpers/mock-helpers";
+import { RepositoryErrorFactory } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import { UpdateDeckUseCase } from "./UpdateDeckUseCase";
+
+const buildDeck = (creatorId = "42") =>
+  Deck.from({
+    id: DeckId.parse("1"),
+    name: "テストDeck",
+    quizIds: [QuizId.parse("quiz-1")],
+    creatorId: CreatorId.parse(creatorId),
+    createdAt: "2023-12-01 10:00:00",
+    lastModifiedAt: "2023-12-01 10:00:00",
+  })._unsafeUnwrap();
+
+const createDeckRepositoryStub = (
+  overrides: Partial<IDeckRepository> = {},
+): IDeckRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findByCreator: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  ...overrides,
+});
+
+describe("UpdateDeckUseCase", () => {
+  it("所有者本人であればDeckを更新できる", async () => {
+    const updatedDeck = Deck.from({
+      id: DeckId.parse("1"),
+      name: "更新後の名前",
+      quizIds: [QuizId.parse("quiz-1")],
+      creatorId: CreatorId.parse("42"),
+      createdAt: "2023-12-01 10:00:00",
+      lastModifiedAt: "2023-12-01 11:00:00",
+    })._unsafeUnwrap();
+
+    const deckRepository = createDeckRepositoryStub({
+      findById: vi.fn().mockReturnValue(createImmediateSuccess(buildDeck())),
+      update: vi.fn().mockReturnValue(createImmediateSuccess(updatedDeck)),
+    });
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const useCase = new UpdateDeckUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute("1", {
+      name: "更新後の名前",
+      creatorFingerprint: "fingerprint-of-42",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.name).toBe("更新後の名前");
+    }
+  });
+
+  it("所有者でない場合はForbiddenErrorを返す", async () => {
+    const deckRepository = createDeckRepositoryStub({
+      findById: vi
+        .fn()
+        .mockReturnValue(createImmediateSuccess(buildDeck("42"))),
+    });
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("99")),
+    };
+    const useCase = new UpdateDeckUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute("1", {
+      name: "更新後の名前",
+      creatorFingerprint: "fingerprint-of-99",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(deckRepository.update).not.toHaveBeenCalled();
+  });
+
+  it("Deckが見つからない場合はエラーを返す", async () => {
+    const deckRepository = createDeckRepositoryStub({
+      findById: vi
+        .fn()
+        .mockReturnValue(
+          createImmediateFailure(RepositoryErrorFactory.findFailed("Deck")),
+        ),
+    });
+    const identityResolver: IUserIdentityResolver = {
+      resolve: vi.fn().mockReturnValue(createImmediateSuccess("42")),
+    };
+    const useCase = new UpdateDeckUseCase(deckRepository, identityResolver);
+
+    const result = await useCase.execute("nonexistent", {
+      name: "更新後の名前",
+      creatorFingerprint: "fingerprint-of-42",
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/api/src/contexts/quiz-learning/application/use-cases/UpdateDeckUseCase.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/UpdateDeckUseCase.ts
@@ -1,0 +1,97 @@
+import { errAsync, ok, type ResultAsync } from "neverthrow";
+import { FindFailedError, UpdateFailedError } from "../../../../shared/errors";
+import type { IUserIdentityResolver } from "../../../../shared/identity/IUserIdentityResolver";
+import { type DeckData, QuizId } from "../../domain/entities/deck/Deck";
+import { DeckForbiddenError, DeckNotFoundError } from "../../domain/errors";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import {
+  DeckUpdateFailedError,
+  type DeckUseCaseError,
+  UseCaseInternalError,
+} from "../errors";
+import { type DeckDto, toDeckDto } from "../mappers/deck-dto";
+
+export type UpdateDeckCommand = {
+  name?: string;
+  description?: string;
+  quizIds?: string[];
+  /** `anonymousSession`ミドルウェアが供給する`c.var.userFingerprint` */
+  creatorFingerprint: string;
+};
+
+/**
+ * Deck部分更新ユースケース（PATCH、ADR-0027参照）
+ */
+export class UpdateDeckUseCase {
+  constructor(
+    private readonly deckRepository: IDeckRepository,
+    private readonly identityResolver: IUserIdentityResolver,
+  ) {}
+
+  execute(
+    id: string,
+    command: UpdateDeckCommand,
+  ): ResultAsync<DeckDto, DeckUseCaseError> {
+    return this.identityResolver
+      .resolve(command.creatorFingerprint)
+      .mapErr(
+        (repositoryError) =>
+          new UseCaseInternalError(
+            "Failed to resolve user identity",
+            repositoryError.message,
+          ),
+      )
+      .andThen((creatorId) =>
+        this.deckRepository
+          .findById(id)
+          .mapErr((repositoryError) => {
+            if (
+              repositoryError instanceof FindFailedError &&
+              repositoryError.details?.toLowerCase().includes("not found")
+            ) {
+              return new DeckNotFoundError(id);
+            }
+            return new UseCaseInternalError(
+              "Failed to get deck",
+              repositoryError.message,
+            );
+          })
+          .andThen((deck) => {
+            if (!deck.isOwnedBy(creatorId)) {
+              return errAsync(new DeckForbiddenError(id));
+            }
+
+            const patch: Partial<DeckData> = {
+              lastModifiedAt: new Date()
+                .toISOString()
+                .slice(0, 19)
+                .replace("T", " "),
+            };
+            if (command.name !== undefined) {
+              patch.name = command.name;
+            }
+            if (command.description !== undefined) {
+              patch.description = command.description;
+            }
+            if (command.quizIds !== undefined) {
+              patch.quizIds = command.quizIds.map((quizId) =>
+                QuizId.parse(quizId),
+              );
+            }
+
+            return this.deckRepository
+              .update(id, patch)
+              .mapErr((repositoryError) => {
+                if (repositoryError instanceof UpdateFailedError) {
+                  return new DeckUpdateFailedError(id, repositoryError.details);
+                }
+                return new UseCaseInternalError(
+                  "Failed to update deck",
+                  repositoryError.message,
+                );
+              });
+          }),
+      )
+      .andThen((deck) => ok(toDeckDto(deck)));
+  }
+}

--- a/api/src/contexts/quiz-learning/application/use-cases/UpdateDeckUseCase.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/UpdateDeckUseCase.ts
@@ -20,7 +20,7 @@ export type UpdateDeckCommand = {
 };
 
 /**
- * Deck部分更新ユースケース（PATCH、ADR-0027参照）
+ * Deck部分更新ユースケース（PATCH、ADR-0028参照）
  */
 export class UpdateDeckUseCase {
   constructor(

--- a/api/src/contexts/quiz-learning/application/use-cases/index.ts
+++ b/api/src/contexts/quiz-learning/application/use-cases/index.ts
@@ -1,0 +1,7 @@
+export * from "./CreateDeckFromSearchUseCase";
+export * from "./CreateDeckFromWrongAnswersUseCase";
+export * from "./CreateDeckUseCase";
+export * from "./DeleteDeckUseCase";
+export * from "./GetDeckUseCase";
+export * from "./GetMyDecksUseCase";
+export * from "./UpdateDeckUseCase";

--- a/api/src/contexts/quiz-learning/domain/entities/deck/Deck.spec.ts
+++ b/api/src/contexts/quiz-learning/domain/entities/deck/Deck.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { CreatorId, Deck, DeckId, QuizId } from "./Deck";
+
+describe("Deck", () => {
+  const validDeckData = {
+    id: DeckId.parse("deck-1"),
+    name: "JavaScript基礎",
+    description: "JavaScriptの基本的な概念",
+    quizIds: [QuizId.parse("quiz-1"), QuizId.parse("quiz-2")],
+    creatorId: CreatorId.parse("user-1"),
+    createdAt: "2023-12-01 10:00:00",
+    lastModifiedAt: "2023-12-01 10:00:00",
+  } as const;
+
+  describe("Entity Creation", () => {
+    it("有効なデータからDeckを構築できる", () => {
+      const result = Deck.from(validDeckData);
+      expect(result.isOk()).toBe(true);
+
+      if (result.isOk()) {
+        const deck = result.value;
+        expect(deck.get("name")).toBe("JavaScript基礎");
+        expect(deck.get("quizIds")).toEqual(["quiz-1", "quiz-2"]);
+        expect(deck.get("creatorId")).toBe("user-1");
+      }
+    });
+
+    it("quizIdsが空配列の場合は拒否する", () => {
+      const result = Deck.from({ ...validDeckData, quizIds: [] });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe("Business Logic", () => {
+    it("isOwnedByは所有者一致でtrueを返す", () => {
+      const result = Deck.from(validDeckData);
+      const deck = result._unsafeUnwrap();
+      expect(deck.isOwnedBy("user-1")).toBe(true);
+    });
+
+    it("isOwnedByは所有者不一致でfalseを返す", () => {
+      const result = Deck.from(validDeckData);
+      const deck = result._unsafeUnwrap();
+      expect(deck.isOwnedBy("user-2")).toBe(false);
+    });
+  });
+
+  describe("Draft Usage", () => {
+    it("Draftパターンで構築できる", () => {
+      const draft = new Deck.Draft();
+      draft.update("name", "React入門");
+      draft.with({
+        id: DeckId.parse("deck-2"),
+        description: undefined,
+        quizIds: [QuizId.parse("quiz-3")],
+        creatorId: CreatorId.parse("user-1"),
+        createdAt: "2023-12-01 10:00:00",
+        lastModifiedAt: "2023-12-01 10:00:00",
+      });
+
+      const entityResult = draft.commit();
+      expect(entityResult.isOk()).toBe(true);
+      if (entityResult.isOk()) {
+        expect(entityResult.value.get("name")).toBe("React入門");
+      }
+    });
+  });
+
+  describe("Immutability", () => {
+    it("update()は新しいインスタンスを返し元のインスタンスは不変", () => {
+      const result = Deck.from(validDeckData);
+      const originalDeck = result._unsafeUnwrap();
+
+      const updatedResult = originalDeck.update("name", "更新後の名前");
+      const updatedDeck = updatedResult._unsafeUnwrap();
+
+      expect(originalDeck).not.toBe(updatedDeck);
+      expect(originalDeck.get("name")).toBe("JavaScript基礎");
+      expect(updatedDeck.get("name")).toBe("更新後の名前");
+    });
+  });
+});

--- a/api/src/contexts/quiz-learning/domain/entities/deck/Deck.ts
+++ b/api/src/contexts/quiz-learning/domain/entities/deck/Deck.ts
@@ -1,0 +1,83 @@
+import { err, ok } from "neverthrow";
+import {
+  DraftBase,
+  EntityBase,
+  type EntityParseError,
+  type EntityParseResult,
+  toIssues,
+} from "../../../../../shared/validation/entity";
+import { suggestDeckPatches } from "./deck-patches";
+import { type DeckData, type DeckInput, DeckSchema } from "./deck-schema";
+
+// Type aliases for Deck-specific types
+export type DeckParseError = EntityParseError<DeckInput>;
+export type DeckParseResult = EntityParseResult<Deck, DeckInput>;
+export type DeckDraft = InstanceType<typeof Deck.Draft>;
+
+// Re-export types for public API
+export type {
+  CreatorId as CreatorIdType,
+  DeckData,
+  DeckId as DeckIdType,
+  DeckInput,
+  QuizId as QuizIdType,
+} from "./deck-schema";
+
+// Re-export runtime brand schemas
+export { CreatorId, DeckId, QuizId } from "./deck-schema";
+
+/**
+ * parseDeck: エンティティの統一エントリーポイント
+ * - 成功: ok(Deck)
+ * - 失敗: err({ issues, patches })
+ *   - patches は候補のみ、採用判断は呼び出し側
+ */
+export function parseDeck(input: unknown): DeckParseResult {
+  const parsed = DeckSchema.safeParse(input);
+  if (parsed.success) return ok(Deck.build(parsed.data));
+
+  const issues = toIssues(parsed.error);
+  const patches = suggestDeckPatches(input, issues);
+  return err({ kind: "parse", issues, patches });
+}
+
+/**
+ * Deck Entity - Immutable domain entity for deck（問題集）management
+ *
+ * 検索結果や手動選択、間違い問題から生成される問題集を表現する。
+ * quiz-management の Quiz/Tag と同じ「schema + EntityBase継承クラス」
+ * パターンに従う。
+ */
+export class Deck extends EntityBase<Deck, typeof DeckSchema> {
+  constructor(data: DeckData) {
+    super(data, parseDeck);
+  }
+
+  /** Internal factory method for validated data */
+  static build(data: DeckData): Deck {
+    return new Deck(data);
+  }
+
+  static from(input: unknown): DeckParseResult {
+    return parseDeck(input);
+  }
+
+  static fromDraft(draft: InstanceType<typeof Deck.Draft>): DeckParseResult {
+    return draft.commit();
+  }
+
+  /**
+   * 指定された識別子（解決済みcreatorId）がこのDeckの所有者かどうかを判定する
+   *
+   * @param creatorId - `IUserIdentityResolver.resolve()`で解決された識別子
+   */
+  isOwnedBy(creatorId: string): boolean {
+    return this.get("creatorId") === creatorId;
+  }
+
+  static Draft = class extends DraftBase<Deck, typeof DeckSchema> {
+    constructor() {
+      super(parseDeck);
+    }
+  };
+}

--- a/api/src/contexts/quiz-learning/domain/entities/deck/deck-patches.spec.ts
+++ b/api/src/contexts/quiz-learning/domain/entities/deck/deck-patches.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { suggestDeckPatches } from "./deck-patches";
+
+describe("deck-patches", () => {
+  it("quizIdsがnull/undefinedの場合は空配列を提案する", () => {
+    const patches = suggestDeckPatches({ quizIds: null }, [
+      { path: ["quizIds"], code: "custom", message: "invalid" },
+    ]);
+
+    expect(patches).toContainEqual({ quizIds: [] });
+  });
+
+  it("該当するIssueがないフィールドには何も提案しない", () => {
+    const patches = suggestDeckPatches({ name: "test" }, []);
+    expect(patches).toEqual([]);
+  });
+
+  it("inputがオブジェクトでない場合は空配列を返す", () => {
+    const patches = suggestDeckPatches(null, [
+      { path: ["quizIds"], code: "custom", message: "invalid" },
+    ]);
+    expect(patches).toEqual([]);
+  });
+});

--- a/api/src/contexts/quiz-learning/domain/entities/deck/deck-patches.ts
+++ b/api/src/contexts/quiz-learning/domain/entities/deck/deck-patches.ts
@@ -1,0 +1,44 @@
+import { isObjectLike } from "../../../../../shared/utils/type-guard";
+import type {
+  EntityPatch,
+  FieldSuggester,
+  Issue,
+} from "../../../../../shared/validation/entity";
+import type { DeckInput } from "./deck-schema";
+
+export type DeckPatch = EntityPatch<DeckInput>;
+
+type DeckFieldSuggester = FieldSuggester<DeckInput>;
+
+// quizIds 用：null/undefinedハンドリング（DeckSchema自体はquizIdsの空配列を許可しないため、
+// 修正提案としてはひとまず空配列を提示し、呼び出し側での再入力を促す）
+export const suggestQuizIdsPatches: DeckFieldSuggester = (value) => {
+  const patches: DeckPatch[] = [];
+
+  if (value == null) {
+    patches.push({ quizIds: [] });
+  }
+
+  return patches;
+};
+
+/** 集約：Issue に該当するフィールドだけを呼ぶ */
+export const suggestDeckPatches = (
+  input: unknown,
+  issues: Issue[],
+): DeckPatch[] => {
+  if (!isObjectLike<DeckInput>(input)) {
+    return [];
+  }
+
+  const needsField = (field: string) =>
+    issues.some((issue) => String(issue.path[0]) === field);
+
+  const patches: DeckPatch[] = [];
+
+  if (needsField("quizIds")) {
+    patches.push(...suggestQuizIdsPatches(input.quizIds));
+  }
+
+  return patches;
+};

--- a/api/src/contexts/quiz-learning/domain/entities/deck/deck-schema.spec.ts
+++ b/api/src/contexts/quiz-learning/domain/entities/deck/deck-schema.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { CreatorId, DeckId, DeckSchema, QuizId } from "./deck-schema";
+
+describe("deck-schema", () => {
+  const validDeckData = {
+    id: DeckId.parse("deck-1"),
+    name: "JavaScript基礎",
+    description: "JavaScriptの基本的な概念",
+    quizIds: [QuizId.parse("quiz-1"), QuizId.parse("quiz-2")],
+    creatorId: CreatorId.parse("user-1"),
+    createdAt: "2023-12-01 10:00:00",
+    lastModifiedAt: "2023-12-01 10:00:00",
+  } as const;
+
+  describe("Brand Types", () => {
+    it.each([
+      ["valid alphanumeric", "deck-1", true],
+      ["empty string", "", false],
+      ["null value", null, false],
+    ])("DeckId should handle %s: %s", (_desc, input, isValid) => {
+      const result = DeckId.safeParse(input);
+      expect(result.success).toBe(isValid);
+    });
+
+    it.each([
+      ["valid alphanumeric", "user-1", true],
+      ["empty string", "", false],
+    ])("CreatorId should handle %s: %s", (_desc, input, isValid) => {
+      const result = CreatorId.safeParse(input);
+      expect(result.success).toBe(isValid);
+    });
+
+    it.each([
+      ["valid alphanumeric", "quiz-1", true],
+      ["empty string", "", false],
+    ])("QuizId should handle %s: %s", (_desc, input, isValid) => {
+      const result = QuizId.safeParse(input);
+      expect(result.success).toBe(isValid);
+    });
+  });
+
+  describe("DeckSchema", () => {
+    it("有効なデータからDeckを構築できる", () => {
+      const result = DeckSchema.safeParse(validDeckData);
+      expect(result.success).toBe(true);
+    });
+
+    it("descriptionは省略可能", () => {
+      const { description: _description, ...rest } = validDeckData;
+      const result = DeckSchema.safeParse(rest);
+      expect(result.success).toBe(true);
+    });
+
+    it("nameが空文字の場合は拒否する", () => {
+      const result = DeckSchema.safeParse({ ...validDeckData, name: "" });
+      expect(result.success).toBe(false);
+    });
+
+    it("nameが200文字を超える場合は拒否する", () => {
+      const result = DeckSchema.safeParse({
+        ...validDeckData,
+        name: "a".repeat(201),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("descriptionが1000文字を超える場合は拒否する", () => {
+      const result = DeckSchema.safeParse({
+        ...validDeckData,
+        description: "a".repeat(1001),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("quizIdsが空配列の場合は拒否する", () => {
+      const result = DeckSchema.safeParse({ ...validDeckData, quizIds: [] });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((issue) => issue.path.includes("quizIds")),
+        ).toBe(true);
+      }
+    });
+
+    it("quizIdsに重複がある場合は拒否する", () => {
+      const result = DeckSchema.safeParse({
+        ...validDeckData,
+        quizIds: [QuizId.parse("quiz-1"), QuizId.parse("quiz-1")],
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((issue) =>
+            issue.message.includes("Duplicate"),
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it("未知のフィールドを含む場合は拒否する（strict）", () => {
+      const result = DeckSchema.safeParse({
+        ...validDeckData,
+        unknownField: "value",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("createdAtがSQLite日時形式でない場合は拒否する", () => {
+      const result = DeckSchema.safeParse({
+        ...validDeckData,
+        createdAt: "2023-12-01T10:00:00.000Z",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/api/src/contexts/quiz-learning/domain/entities/deck/deck-schema.ts
+++ b/api/src/contexts/quiz-learning/domain/entities/deck/deck-schema.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { sqliteDateTimeSchema } from "../../../../../shared/schemas/datetime.schema";
+
+// Brand types for type safety
+export const DeckId = z.string().min(1).brand<"DeckId">();
+export type DeckId = z.infer<typeof DeckId>;
+
+export const CreatorId = z.string().min(1).brand<"DeckCreatorId">();
+export type CreatorId = z.infer<typeof CreatorId>;
+
+// quiz-management の QuizId とは別に、Deck視点での参照用ローカルbrand型として定義する
+// （境界づけられたコンテキスト間の型直接共有を避けるため。値としてはquiz-managementのQuizIdと同一形式）
+export const QuizId = z.string().min(1).brand<"DeckQuizId">();
+export type QuizId = z.infer<typeof QuizId>;
+
+export const DeckSchema = z
+  .object({
+    id: DeckId,
+    name: z.string().trim().min(1).max(200),
+    description: z.string().max(1000).optional(),
+    quizIds: z.array(QuizId).min(1),
+    creatorId: CreatorId,
+    createdAt: sqliteDateTimeSchema,
+    lastModifiedAt: sqliteDateTimeSchema,
+  })
+  .strict()
+  .superRefine((deck, ctx) => {
+    const uniqueQuizIds = new Set(deck.quizIds);
+    if (uniqueQuizIds.size !== deck.quizIds.length) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Duplicate quiz IDs are not allowed",
+        path: ["quizIds"],
+      });
+    }
+  });
+
+export type DeckData = z.output<typeof DeckSchema>;
+export type DeckInput = z.input<typeof DeckSchema>;

--- a/api/src/contexts/quiz-learning/domain/errors/deck-errors.ts
+++ b/api/src/contexts/quiz-learning/domain/errors/deck-errors.ts
@@ -1,0 +1,36 @@
+import { ForbiddenError, NotFoundError } from "../../../../shared/errors";
+
+/**
+ * Deckドメイン固有のエラークラス群
+ *
+ * quiz-learningコンテキストにおけるDeck集約のビジネスルール違反を表現する。
+ */
+
+/**
+ * 指定されたDeckが見つからない場合のエラー
+ */
+export class DeckNotFoundError extends NotFoundError {
+  readonly deckId: string;
+
+  constructor(deckId: string, requestId?: string) {
+    super(`Deck with ID '${deckId}' not found`, requestId);
+    this.deckId = deckId;
+  }
+}
+
+/**
+ * 所有者以外がDeckを更新・削除しようとした場合のエラー
+ */
+export class DeckForbiddenError extends ForbiddenError {
+  readonly deckId: string;
+
+  constructor(deckId: string, requestId?: string) {
+    super(
+      `Deck ${deckId} operation is only allowed for the creator`,
+      requestId,
+    );
+    this.deckId = deckId;
+  }
+}
+
+export type DeckDomainError = DeckNotFoundError | DeckForbiddenError;

--- a/api/src/contexts/quiz-learning/domain/errors/index.ts
+++ b/api/src/contexts/quiz-learning/domain/errors/index.ts
@@ -1,0 +1,5 @@
+export {
+  type DeckDomainError,
+  DeckForbiddenError,
+  DeckNotFoundError,
+} from "./deck-errors";

--- a/api/src/contexts/quiz-learning/domain/repositories/IAttemptQueryRepository.ts
+++ b/api/src/contexts/quiz-learning/domain/repositories/IAttemptQueryRepository.ts
@@ -1,0 +1,23 @@
+import type { ResultAsync } from "neverthrow";
+import type { RepositoryError } from "../../../../shared/errors";
+
+/**
+ * 「間違い問題からDeckを生成する」ユースケース専用の読み取り専用ポート
+ *
+ * Session/Answer集約自体はissue #47のスコープ外（次issueで実装）だが、
+ * `POST /decks/wrong-questions`は既存の`Attempt`テーブルを参照する必要が
+ * あるため、最小限の読み取り専用クエリとして定義する。
+ */
+export interface IAttemptQueryRepository {
+  /**
+   * 指定した作成者が間違えた問題のQuizIdを新しい順に取得する
+   *
+   * @param creatorId - `IUserIdentityResolver.resolve()`で解決された識別子
+   * @param params.sinceDays - 何日前までのAttemptを対象にするか
+   * @param params.maxQuizzes - 取得する最大件数
+   */
+  findWrongQuizIds(
+    creatorId: string,
+    params: { sinceDays: number; maxQuizzes: number },
+  ): ResultAsync<string[], RepositoryError>;
+}

--- a/api/src/contexts/quiz-learning/domain/repositories/IDeckRepository.ts
+++ b/api/src/contexts/quiz-learning/domain/repositories/IDeckRepository.ts
@@ -1,0 +1,30 @@
+import type { ResultAsync } from "neverthrow";
+import type { RepositoryError } from "../../../../shared/errors";
+import type { Deck, DeckData } from "../entities/deck/Deck";
+
+/**
+ * Deck集約のリポジトリインターフェース
+ *
+ * quiz-managementのIQuizRepositoryと同じ`ResultAsync<T, RepositoryError>`
+ * パターンに従う。
+ */
+export interface IDeckRepository {
+  create(deck: Deck): ResultAsync<Deck, RepositoryError>;
+
+  findById(id: string): ResultAsync<Deck, RepositoryError>;
+
+  findByCreator(
+    creatorId: string,
+    options?: { limit?: number; offset?: number },
+  ): ResultAsync<
+    { items: Deck[]; totalCount: number; hasMore: boolean },
+    RepositoryError
+  >;
+
+  update(
+    id: string,
+    patch: Partial<DeckData>,
+  ): ResultAsync<Deck, RepositoryError>;
+
+  delete(id: string): ResultAsync<void, RepositoryError>;
+}

--- a/api/src/contexts/quiz-learning/infrastructure/mappers/D1DeckMapper.spec.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/mappers/D1DeckMapper.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { InternalServerError } from "../../../../shared/errors";
+import { D1DeckMapper } from "./D1DeckMapper";
+
+describe("D1DeckMapper", () => {
+  const validRawRow = {
+    id: 1,
+    name: "JavaScript基礎",
+    description: "説明文",
+    quiz_ids: "[1,9,14]",
+    creator_id: 1,
+    created_at: "2023-12-01 10:00:00",
+    last_modified_at: "2023-12-01 10:00:00",
+  };
+
+  describe("fromRow", () => {
+    it("有効な生の行データをDeckエンティティに変換する", () => {
+      const result = D1DeckMapper.fromRow(validRawRow);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const deck = result.value;
+        expect(deck.get("id")).toBe("1");
+        expect(deck.get("name")).toBe("JavaScript基礎");
+        expect(deck.get("description")).toBe("説明文");
+        expect(deck.get("quizIds")).toEqual(["1", "9", "14"]);
+        expect(deck.get("creatorId")).toBe("1");
+      }
+    });
+
+    it("descriptionがnullの行データも変換できる", () => {
+      const result = D1DeckMapper.fromRow({
+        ...validRawRow,
+        description: null,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.get("description")).toBeUndefined();
+      }
+    });
+
+    it("quiz_idsが空配列の場合はエラーを返す", () => {
+      const result = D1DeckMapper.fromRow({
+        ...validRawRow,
+        quiz_ids: "[]",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(InternalServerError);
+      }
+    });
+
+    it("行データの形が不正な場合はエラーを返す", () => {
+      const result = D1DeckMapper.fromRow({ id: 1 });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(InternalServerError);
+        expect(result.error.details).toContain("Invalid deck row");
+      }
+    });
+  });
+
+  describe("fromRows", () => {
+    it("複数の行データを変換する", () => {
+      const result = D1DeckMapper.fromRows([
+        validRawRow,
+        { ...validRawRow, id: 2, name: "React入門" },
+      ]);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(2);
+        expect(result.value[1]?.get("name")).toBe("React入門");
+      }
+    });
+
+    it("いずれかの行が不正な場合はエラーを返す", () => {
+      const result = D1DeckMapper.fromRows([
+        validRawRow,
+        { ...validRawRow, id: 2, quiz_ids: "[]" },
+      ]);
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+});

--- a/api/src/contexts/quiz-learning/infrastructure/mappers/D1DeckMapper.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/mappers/D1DeckMapper.ts
@@ -1,0 +1,87 @@
+import { err, ok, type Result } from "neverthrow";
+import { type AppError, InternalServerError } from "../../../../shared/errors";
+import { Deck } from "../../domain/entities/deck/Deck";
+import { zodDeckRowSchema } from "./d1-deck-types";
+
+/**
+ * D1データベースのDeck行データをDeckエンティティに変換するマッパー
+ *
+ * quiz-managementのD1QuizSummaryMapperと同じパターンに従う。
+ * D1の`.first()`/`.all()`は型パラメータを付けてもランタイム検証を
+ * 行わないため、本マッパーが生の行データを受け取りzodで検証・変換する。
+ */
+// biome-ignore lint/complexity/noStaticOnlyClass: This utility class is intended to be static-only
+export class D1DeckMapper {
+  /**
+   * D1データベースの行データ（未検証）をDeckエンティティに変換
+   *
+   * @param row - D1データベースから取得した生のDeck行データ
+   * @returns Deckエンティティ、またはマッピングエラー
+   */
+  static fromRow(row: unknown): Result<Deck, AppError> {
+    const parsed = zodDeckRowSchema.safeParse(row);
+    if (!parsed.success) {
+      return err(
+        new InternalServerError(
+          "Internal server error",
+          `Invalid deck row: ${parsed.error.message}`,
+        ),
+      );
+    }
+    const rowData = parsed.data;
+
+    const createData = {
+      id: rowData.id,
+      name: rowData.name,
+      ...(rowData.description !== undefined && {
+        description: rowData.description,
+      }),
+      quizIds: rowData.quiz_ids,
+      creatorId: rowData.creator_id,
+      createdAt: rowData.created_at,
+      lastModifiedAt: rowData.last_modified_at,
+    };
+
+    const deckResult = Deck.from(createData);
+
+    return deckResult.mapErr(
+      (error) =>
+        new InternalServerError(
+          "Internal server error",
+          `Failed to create Deck from row data: ${JSON.stringify(error)}`,
+        ),
+    );
+  }
+
+  /**
+   * 複数のD1データベース行データ（未検証）をDeckエンティティ配列に変換
+   *
+   * @param rows - D1データベースから取得した生のDeck行データの配列
+   * @returns Deckエンティティ配列、またはマッピングエラー
+   */
+  static fromRows(rows: unknown[]): Result<Deck[], AppError> {
+    const results: Deck[] = [];
+    const errors: Error[] = [];
+
+    for (const [index, row] of rows.entries()) {
+      const mappingResult = D1DeckMapper.fromRow(row);
+
+      if (mappingResult.isErr()) {
+        errors.push(new Error(`Row ${index}: ${mappingResult.error.message}`));
+        continue;
+      }
+      results.push(mappingResult.value);
+    }
+
+    if (errors.length > 0) {
+      return err(
+        new InternalServerError(
+          "Internal server error",
+          `Failed to map ${errors.length}/${rows.length} rows: ${errors.map((e) => e.message).join("; ")}`,
+        ),
+      );
+    }
+
+    return ok(results);
+  }
+}

--- a/api/src/contexts/quiz-learning/infrastructure/mappers/d1-deck-types.spec.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/mappers/d1-deck-types.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { zodDeckRowSchema } from "./d1-deck-types";
+
+describe("d1-deck-types", () => {
+  describe("zodDeckRowSchema", () => {
+    it("D1の行データ（数値ID・JSON文字列quiz_ids）をパースできる", () => {
+      const result = zodDeckRowSchema.safeParse({
+        id: 1,
+        name: "JavaScript基礎",
+        description: "説明文",
+        quiz_ids: "[1,9,14,20]",
+        creator_id: 1,
+        created_at: "2023-12-01 10:00:00",
+        last_modified_at: "2023-12-01 10:00:00",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.id).toBe("1");
+        expect(result.data.creator_id).toBe("1");
+        expect(result.data.quiz_ids).toEqual(["1", "9", "14", "20"]);
+      }
+    });
+
+    it("descriptionがnullの場合はundefinedとして扱う", () => {
+      const result = zodDeckRowSchema.safeParse({
+        id: 1,
+        name: "JavaScript基礎",
+        description: null,
+        quiz_ids: "[1]",
+        creator_id: 1,
+        created_at: "2023-12-01 10:00:00",
+        last_modified_at: "2023-12-01 10:00:00",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.description).toBeUndefined();
+      }
+    });
+
+    it("quiz_idsが不正なJSONの場合は失敗する", () => {
+      const result = zodDeckRowSchema.safeParse({
+        id: 1,
+        name: "JavaScript基礎",
+        quiz_ids: "not-json",
+        creator_id: 1,
+        created_at: "2023-12-01 10:00:00",
+        last_modified_at: "2023-12-01 10:00:00",
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("quiz_idsが配列でないJSONの場合は失敗する", () => {
+      const result = zodDeckRowSchema.safeParse({
+        id: 1,
+        name: "JavaScript基礎",
+        quiz_ids: '{"not":"an array"}',
+        creator_id: 1,
+        created_at: "2023-12-01 10:00:00",
+        last_modified_at: "2023-12-01 10:00:00",
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/api/src/contexts/quiz-learning/infrastructure/mappers/d1-deck-types.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/mappers/d1-deck-types.ts
@@ -1,0 +1,60 @@
+/**
+ * D1データベースのDeck行データの型定義とマッパー (Zod版)
+ *
+ * quiz-managementのd1-types.tsと同じパターンに従う。
+ */
+
+import { z } from "zod";
+
+export type D1QueryParam = string | number | boolean | null;
+
+/**
+ * D1の数値IDを文字列に変換するスキーマ
+ */
+const d1IdSchema = z.union([z.string(), z.number()]).transform(String);
+
+/**
+ * `quiz_ids` カラム（JSON文字列、例: "[1,9,14,20]"）を文字列配列に変換するスキーマ
+ *
+ * D1/SQLite上は配列型が存在しないため、TypeSpecのconvert-to-sqlite.tsが
+ * `QuizId[]` を `TEXT` カラムに変換している（api/spec/scripts/sqlite-mappings.ts参照）。
+ */
+const quizIdsJsonSchema = z.string().transform((value, ctx) => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    ctx.addIssue({ code: "custom", message: "quiz_ids must be valid JSON" });
+    return z.NEVER;
+  }
+  if (!Array.isArray(parsed)) {
+    ctx.addIssue({ code: "custom", message: "quiz_ids must be a JSON array" });
+    return z.NEVER;
+  }
+  return parsed.map((id) => String(id));
+});
+
+/**
+ * Deck関連のD1行データスキーマ
+ */
+export const zodDeckRowSchema = z
+  .object({
+    id: d1IdSchema,
+    name: z.string(),
+    description: z.string().nullish(),
+    quiz_ids: quizIdsJsonSchema,
+    creator_id: d1IdSchema,
+    created_at: z.string(),
+    last_modified_at: z.string(),
+  })
+  .transform((data) => ({
+    id: data.id,
+    name: data.name,
+    quiz_ids: data.quiz_ids,
+    creator_id: data.creator_id,
+    created_at: data.created_at,
+    last_modified_at: data.last_modified_at,
+    ...(data.description != null && { description: data.description }),
+  }));
+
+export type DeckRow = z.infer<typeof zodDeckRowSchema>;

--- a/api/src/contexts/quiz-learning/infrastructure/repositories/D1AttemptQueryRepository.spec.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/repositories/D1AttemptQueryRepository.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { D1AttemptQueryRepository } from "./D1AttemptQueryRepository";
+
+const createMockDb = (results: unknown[]) => {
+  const all = vi.fn().mockResolvedValue({ results });
+  const bind = vi.fn().mockReturnValue({ all });
+  const prepare = vi.fn().mockReturnValue({ bind });
+  return { db: { prepare } as unknown as D1Database, prepare, bind, all };
+};
+
+describe("D1AttemptQueryRepository", () => {
+  it("間違えた問題のquiz_idを文字列配列として返す", async () => {
+    const { db, bind, prepare } = createMockDb([
+      { quiz_id: 1 },
+      { quiz_id: 2 },
+    ]);
+    const repository = new D1AttemptQueryRepository(db);
+
+    const result = await repository.findWrongQuizIds("42", {
+      sinceDays: 30,
+      maxQuizzes: 50,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual(["1", "2"]);
+    }
+    expect(bind).toHaveBeenCalledWith("42", expect.any(String), 50);
+    expect(prepare).toHaveBeenCalledWith(expect.stringContaining("DISTINCT"));
+  });
+
+  it("SELECT失敗時はRepositoryErrorを返す", async () => {
+    const all = vi.fn().mockRejectedValue(new Error("SELECT failed"));
+    const bind = vi.fn().mockReturnValue({ all });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+    const repository = new D1AttemptQueryRepository(db);
+
+    const result = await repository.findWrongQuizIds("42", {
+      sinceDays: 30,
+      maxQuizzes: 50,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/api/src/contexts/quiz-learning/infrastructure/repositories/D1AttemptQueryRepository.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/repositories/D1AttemptQueryRepository.ts
@@ -1,0 +1,60 @@
+import { ResultAsync } from "neverthrow";
+import { z } from "zod";
+import {
+  type RepositoryError,
+  RepositoryErrorFactory,
+} from "../../../../shared/errors";
+import type { IAttemptQueryRepository } from "../../domain/repositories/IAttemptQueryRepository";
+
+const ENTITY_NAME = "Attempt";
+
+const wrongQuizRowSchema = z.object({
+  quiz_id: z.union([z.string(), z.number()]).transform(String),
+});
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function toSqliteDateTime(date: Date): string {
+  return date.toISOString().slice(0, 19).replace("T", " ");
+}
+
+/**
+ * D1（`Attempt`テーブル）を用いた間違い問題クエリの実装
+ *
+ * Session/Answer集約自体は次issueのスコープのため、読み取り専用の
+ * 最小限のクエリのみ提供する（domain/repositories/IAttemptQueryRepository.ts参照）。
+ */
+export class D1AttemptQueryRepository implements IAttemptQueryRepository {
+  constructor(private readonly db: D1Database) {}
+
+  findWrongQuizIds(
+    creatorId: string,
+    params: { sinceDays: number; maxQuizzes: number },
+  ): ResultAsync<string[], RepositoryError> {
+    const sinceDate = toSqliteDateTime(
+      new Date(Date.now() - params.sinceDays * MS_PER_DAY),
+    );
+
+    return ResultAsync.fromPromise(
+      this.db
+        .prepare(`
+          SELECT DISTINCT quiz_id FROM Attempt
+          WHERE user_id = ? AND is_correct = 0 AND answered_at >= ?
+          ORDER BY answered_at DESC
+          LIMIT ?
+        `)
+        .bind(creatorId, sinceDate, params.maxQuizzes)
+        .all(),
+      (error) =>
+        RepositoryErrorFactory.findFailed(
+          ENTITY_NAME,
+          error instanceof Error ? error : new Error("Unknown find error"),
+        ),
+    ).map((result) =>
+      result.results.flatMap((row) => {
+        const parsed = wrongQuizRowSchema.safeParse(row);
+        return parsed.success ? [parsed.data.quiz_id] : [];
+      }),
+    );
+  }
+}

--- a/api/src/contexts/quiz-learning/infrastructure/repositories/D1DeckRepository.spec.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/repositories/D1DeckRepository.spec.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import { D1DeckRepository } from "./D1DeckRepository";
+
+const buildDeck = () =>
+  Deck.from({
+    id: DeckId.parse("1"),
+    name: "テストDeck",
+    description: "説明文",
+    quizIds: [QuizId.parse("quiz-1"), QuizId.parse("quiz-2")],
+    creatorId: CreatorId.parse("42"),
+    createdAt: "2023-12-01 10:00:00",
+    lastModifiedAt: "2023-12-01 10:00:00",
+  })._unsafeUnwrap();
+
+type MockDbOptions = {
+  first?: unknown;
+  run?: { meta: { last_row_id: number } };
+  all?: { results: unknown[] };
+};
+
+const createMockDb = (options: MockDbOptions = {}) => {
+  const first = vi.fn().mockResolvedValue(options.first ?? null);
+  const run = vi
+    .fn()
+    .mockResolvedValue(options.run ?? { meta: { last_row_id: 1 } });
+  const all = vi.fn().mockResolvedValue(options.all ?? { results: [] });
+  const bind = vi.fn().mockReturnValue({ first, run, all });
+  const prepare = vi.fn().mockReturnValue({ bind });
+  const db = { prepare } as unknown as D1Database;
+  return { db, prepare, bind, first, run, all };
+};
+
+describe("D1DeckRepository", () => {
+  describe("create", () => {
+    it("INSERT成功時、last_row_idを持つDeckを返す", async () => {
+      const { db } = createMockDb({ run: { meta: { last_row_id: 7 } } });
+      const repository = new D1DeckRepository(db);
+
+      const result = await repository.create(buildDeck());
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.get("id")).toBe("7");
+        expect(result.value.get("name")).toBe("テストDeck");
+      }
+    });
+
+    it("INSERT失敗時はRepositoryErrorを返す", async () => {
+      const first = vi.fn();
+      const run = vi.fn().mockRejectedValue(new Error("INSERT failed"));
+      const bind = vi.fn().mockReturnValue({ first, run });
+      const prepare = vi.fn().mockReturnValue({ bind });
+      const db = { prepare } as unknown as D1Database;
+      const repository = new D1DeckRepository(db);
+
+      const result = await repository.create(buildDeck());
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe("findById", () => {
+    it("見つかった場合はDeckを返す", async () => {
+      const { db } = createMockDb({
+        first: {
+          id: 1,
+          name: "テストDeck",
+          description: "説明文",
+          quiz_ids: "[1,2]",
+          creator_id: 42,
+          created_at: "2023-12-01 10:00:00",
+          last_modified_at: "2023-12-01 10:00:00",
+        },
+      });
+      const repository = new D1DeckRepository(db);
+
+      const result = await repository.findById("1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.get("name")).toBe("テストDeck");
+      }
+    });
+
+    it("見つからない場合はRepositoryErrorを返す", async () => {
+      const { db } = createMockDb({ first: null });
+      const repository = new D1DeckRepository(db);
+
+      const result = await repository.findById("nonexistent");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.details?.toLowerCase()).toContain("not found");
+      }
+    });
+
+    it("SELECT失敗時はRepositoryErrorを返す", async () => {
+      const first = vi.fn().mockRejectedValue(new Error("SELECT failed"));
+      const bind = vi.fn().mockReturnValue({ first });
+      const prepare = vi.fn().mockReturnValue({ bind });
+      const db = { prepare } as unknown as D1Database;
+      const repository = new D1DeckRepository(db);
+
+      const result = await repository.findById("1");
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe("findByCreator", () => {
+    it("作成者のDeck一覧とtotalCount/hasMoreを返す", async () => {
+      const { db } = createMockDb({
+        first: { total: 3 },
+        all: {
+          results: [
+            {
+              id: 1,
+              name: "Deck1",
+              quiz_ids: "[1]",
+              creator_id: 42,
+              created_at: "2023-12-01 10:00:00",
+              last_modified_at: "2023-12-01 10:00:00",
+            },
+            {
+              id: 2,
+              name: "Deck2",
+              quiz_ids: "[2]",
+              creator_id: 42,
+              created_at: "2023-12-01 10:00:00",
+              last_modified_at: "2023-12-01 10:00:00",
+            },
+          ],
+        },
+      });
+      const repository = new D1DeckRepository(db);
+
+      const result = await repository.findByCreator("42", {
+        limit: 2,
+        offset: 0,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.items).toHaveLength(2);
+        expect(result.value.totalCount).toBe(3);
+        expect(result.value.hasMore).toBe(true);
+      }
+    });
+  });
+
+  describe("update", () => {
+    it("更新後のDeckを再取得して返す", async () => {
+      const first = vi.fn().mockResolvedValue({
+        id: 1,
+        name: "更新後の名前",
+        quiz_ids: "[1]",
+        creator_id: 42,
+        created_at: "2023-12-01 10:00:00",
+        last_modified_at: "2023-12-01 11:00:00",
+      });
+      const run = vi.fn().mockResolvedValue({ meta: {} });
+      const bind = vi.fn().mockReturnValue({ first, run });
+      const prepare = vi.fn().mockReturnValue({ bind });
+      const db = { prepare } as unknown as D1Database;
+      const repository = new D1DeckRepository(db);
+
+      const result = await repository.update("1", { name: "更新後の名前" });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.get("name")).toBe("更新後の名前");
+      }
+    });
+
+    it("更新フィールドが空の場合はRepositoryErrorを返す", async () => {
+      const { db } = createMockDb();
+      const repository = new D1DeckRepository(db);
+
+      const result = await repository.update("1", {});
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe("delete", () => {
+    it("DELETE成功時はvoidを返す", async () => {
+      const { db } = createMockDb();
+      const repository = new D1DeckRepository(db);
+
+      const result = await repository.delete("1");
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it("DELETE失敗時はRepositoryErrorを返す", async () => {
+      const run = vi.fn().mockRejectedValue(new Error("DELETE failed"));
+      const bind = vi.fn().mockReturnValue({ run });
+      const prepare = vi.fn().mockReturnValue({ bind });
+      const db = { prepare } as unknown as D1Database;
+      const repository = new D1DeckRepository(db);
+
+      const result = await repository.delete("1");
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+});

--- a/api/src/contexts/quiz-learning/infrastructure/repositories/D1DeckRepository.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/repositories/D1DeckRepository.ts
@@ -1,0 +1,221 @@
+import { errAsync, ResultAsync } from "neverthrow";
+import {
+  type RepositoryError,
+  RepositoryErrorFactory,
+} from "../../../../shared/errors";
+import { Deck, type DeckData } from "../../domain/entities/deck/Deck";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+import { D1DeckMapper } from "../mappers/D1DeckMapper";
+import type { D1QueryParam } from "../mappers/d1-deck-types";
+
+const ENTITY_NAME = "Deck";
+
+const SELECT_COLUMNS =
+  "id, name, description, quiz_ids, creator_id, created_at, last_modified_at";
+
+/**
+ * Cloudflare D1データベースを使用したDeckリポジトリ実装
+ *
+ * quiz-managementのD1QuizRepositoryと同じ`ResultAsync.fromPromise` +
+ * `RepositoryErrorFactory`パターンに従う。
+ */
+export class D1DeckRepository implements IDeckRepository {
+  constructor(private readonly db: D1Database) {}
+
+  create(deck: Deck): ResultAsync<Deck, RepositoryError> {
+    return ResultAsync.fromPromise(
+      this.db
+        .prepare(`
+          INSERT INTO Deck (name, description, quiz_ids, creator_id, created_at, last_modified_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+        `)
+        .bind(
+          deck.get("name"),
+          deck.get("description") ?? null,
+          JSON.stringify(deck.get("quizIds")),
+          deck.get("creatorId"),
+          deck.get("createdAt"),
+          deck.get("lastModifiedAt"),
+        )
+        .run(),
+      (error) =>
+        RepositoryErrorFactory.createFailed(
+          ENTITY_NAME,
+          error instanceof Error ? error : new Error("Unknown create error"),
+        ),
+    ).andThen((result) => {
+      const generatedId = String(result.meta.last_row_id);
+      const rebuilt = Deck.from({ ...deck.toData(), id: generatedId });
+      if (rebuilt.isErr()) {
+        return errAsync(
+          RepositoryErrorFactory.createFailed(
+            ENTITY_NAME,
+            new Error(
+              `Failed to rebuild deck with generated id: ${JSON.stringify(rebuilt.error)}`,
+            ),
+          ),
+        );
+      }
+      return ResultAsync.fromSafePromise(Promise.resolve(rebuilt.value));
+    });
+  }
+
+  findById(id: string): ResultAsync<Deck, RepositoryError> {
+    return ResultAsync.fromPromise(
+      this.db
+        .prepare(`SELECT ${SELECT_COLUMNS} FROM Deck WHERE id = ?`)
+        .bind(id)
+        .first(),
+      (error) =>
+        RepositoryErrorFactory.findFailed(
+          ENTITY_NAME,
+          error instanceof Error ? error : new Error("Unknown find error"),
+        ),
+    ).andThen((row) => {
+      if (row === null) {
+        return errAsync(
+          RepositoryErrorFactory.findFailed(
+            ENTITY_NAME,
+            new Error(`Deck not found: ${id}`),
+          ),
+        );
+      }
+      return mapRowToDeck(row);
+    });
+  }
+
+  findByCreator(
+    creatorId: string,
+    options: { limit?: number; offset?: number } = {},
+  ): ResultAsync<
+    { items: Deck[]; totalCount: number; hasMore: boolean },
+    RepositoryError
+  > {
+    const limit = options.limit ?? 20;
+    const offset = options.offset ?? 0;
+
+    const countQuery = ResultAsync.fromPromise(
+      this.db
+        .prepare("SELECT COUNT(*) as total FROM Deck WHERE creator_id = ?")
+        .bind(creatorId)
+        .first<{ total: number }>(),
+      (error) =>
+        RepositoryErrorFactory.findFailed(
+          ENTITY_NAME,
+          error instanceof Error ? error : new Error("Failed to count decks"),
+        ),
+    );
+
+    const dataQuery = ResultAsync.fromPromise(
+      this.db
+        .prepare(
+          `SELECT ${SELECT_COLUMNS} FROM Deck WHERE creator_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+        )
+        .bind(creatorId, limit, offset)
+        .all(),
+      (error) =>
+        RepositoryErrorFactory.findFailed(
+          ENTITY_NAME,
+          error instanceof Error ? error : new Error("Failed to fetch decks"),
+        ),
+    );
+
+    return ResultAsync.combine([countQuery, dataQuery]).andThen(
+      ([countResult, dataResult]) => {
+        const totalCount = countResult?.total ?? 0;
+
+        const mappingResult = D1DeckMapper.fromRows(dataResult.results);
+        if (mappingResult.isErr()) {
+          return errAsync(
+            RepositoryErrorFactory.findFailed(
+              ENTITY_NAME,
+              new Error(
+                `Failed to map deck rows: ${mappingResult.error.message}`,
+              ),
+            ),
+          );
+        }
+
+        return ResultAsync.fromSafePromise(
+          Promise.resolve({
+            items: mappingResult.value,
+            totalCount,
+            hasMore: offset + limit < totalCount,
+          }),
+        );
+      },
+    );
+  }
+
+  update(
+    id: string,
+    patch: Partial<DeckData>,
+  ): ResultAsync<Deck, RepositoryError> {
+    const fields: string[] = [];
+    const params: D1QueryParam[] = [];
+
+    if (patch.name !== undefined) {
+      fields.push("name = ?");
+      params.push(patch.name);
+    }
+    if (patch.description !== undefined) {
+      fields.push("description = ?");
+      params.push(patch.description);
+    }
+    if (patch.quizIds !== undefined) {
+      fields.push("quiz_ids = ?");
+      params.push(JSON.stringify(patch.quizIds));
+    }
+    if (patch.lastModifiedAt !== undefined) {
+      fields.push("last_modified_at = ?");
+      params.push(patch.lastModifiedAt);
+    }
+
+    if (fields.length === 0) {
+      return errAsync(
+        RepositoryErrorFactory.updateFailed(
+          ENTITY_NAME,
+          new Error("No fields to update"),
+        ),
+      );
+    }
+
+    params.push(id);
+
+    return ResultAsync.fromPromise(
+      this.db
+        .prepare(`UPDATE Deck SET ${fields.join(", ")} WHERE id = ?`)
+        .bind(...params)
+        .run(),
+      (error) =>
+        RepositoryErrorFactory.updateFailed(
+          ENTITY_NAME,
+          error instanceof Error ? error : new Error("Unknown update error"),
+        ),
+    ).andThen(() => this.findById(id));
+  }
+
+  delete(id: string): ResultAsync<void, RepositoryError> {
+    return ResultAsync.fromPromise(
+      this.db.prepare("DELETE FROM Deck WHERE id = ?").bind(id).run(),
+      (error) =>
+        RepositoryErrorFactory.deleteFailed(
+          ENTITY_NAME,
+          error instanceof Error ? error : new Error("Unknown delete error"),
+        ),
+    ).map(() => undefined);
+  }
+}
+
+function mapRowToDeck(row: unknown): ResultAsync<Deck, RepositoryError> {
+  const mappingResult = D1DeckMapper.fromRow(row);
+  if (mappingResult.isErr()) {
+    return errAsync(
+      RepositoryErrorFactory.findFailed(
+        ENTITY_NAME,
+        new Error(`Failed to map deck row: ${mappingResult.error.message}`),
+      ),
+    );
+  }
+  return ResultAsync.fromSafePromise(Promise.resolve(mappingResult.value));
+}

--- a/api/src/contexts/quiz-learning/infrastructure/repositories/MockAttemptQueryRepository.spec.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/repositories/MockAttemptQueryRepository.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { MockAttemptQueryRepository } from "./MockAttemptQueryRepository";
+
+describe("MockAttemptQueryRepository", () => {
+  it("常に空配列を返す（Session/Answer未実装のスコープ内簡易実装）", async () => {
+    const repository = new MockAttemptQueryRepository();
+
+    const result = await repository.findWrongQuizIds("42", {
+      sinceDays: 30,
+      maxQuizzes: 50,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual([]);
+    }
+  });
+
+  it("seed()で登録したデータを返す", async () => {
+    const repository = new MockAttemptQueryRepository();
+    repository.seed("42", ["quiz-1", "quiz-2"]);
+
+    const result = await repository.findWrongQuizIds("42", {
+      sinceDays: 30,
+      maxQuizzes: 50,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual(["quiz-1", "quiz-2"]);
+    }
+  });
+
+  it("maxQuizzesで件数を制限する", async () => {
+    const repository = new MockAttemptQueryRepository();
+    repository.seed("42", ["quiz-1", "quiz-2", "quiz-3"]);
+
+    const result = await repository.findWrongQuizIds("42", {
+      sinceDays: 30,
+      maxQuizzes: 2,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(2);
+    }
+  });
+});

--- a/api/src/contexts/quiz-learning/infrastructure/repositories/MockAttemptQueryRepository.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/repositories/MockAttemptQueryRepository.ts
@@ -1,0 +1,25 @@
+import { okAsync, type ResultAsync } from "neverthrow";
+import type { RepositoryError } from "../../../../shared/errors";
+import type { IAttemptQueryRepository } from "../../domain/repositories/IAttemptQueryRepository";
+
+/**
+ * テスト・開発環境向けの間違い問題クエリのin-memoryモック実装
+ *
+ * Attempt集約自体は未実装（Session/Answerは次issueのスコープ）のため、
+ * デフォルトでは常に空を返す。テストでは`seed()`で疑似データを登録できる。
+ */
+export class MockAttemptQueryRepository implements IAttemptQueryRepository {
+  private readonly store = new Map<string, string[]>();
+
+  seed(creatorId: string, quizIds: string[]): void {
+    this.store.set(creatorId, quizIds);
+  }
+
+  findWrongQuizIds(
+    creatorId: string,
+    params: { sinceDays: number; maxQuizzes: number },
+  ): ResultAsync<string[], RepositoryError> {
+    const quizIds = this.store.get(creatorId) ?? [];
+    return okAsync(quizIds.slice(0, params.maxQuizzes));
+  }
+}

--- a/api/src/contexts/quiz-learning/infrastructure/repositories/MockDeckRepository.spec.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/repositories/MockDeckRepository.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  CreatorId,
+  Deck,
+  DeckId,
+  QuizId,
+} from "../../domain/entities/deck/Deck";
+import { MockDeckRepository } from "./MockDeckRepository";
+
+const buildDeck = (overrides: { id?: string; creatorId?: string } = {}) =>
+  Deck.from({
+    id: DeckId.parse(overrides.id ?? "1"),
+    name: "テストDeck",
+    quizIds: [QuizId.parse("quiz-1")],
+    creatorId: CreatorId.parse(overrides.creatorId ?? "42"),
+    createdAt: "2023-12-01 10:00:00",
+    lastModifiedAt: "2023-12-01 10:00:00",
+  })._unsafeUnwrap();
+
+describe("MockDeckRepository", () => {
+  it("createで追加したDeckをfindByIdで取得できる", async () => {
+    const repository = new MockDeckRepository();
+    const deck = buildDeck();
+
+    const createResult = await repository.create(deck);
+    expect(createResult.isOk()).toBe(true);
+
+    const findResult = await repository.findById("1");
+    expect(findResult.isOk()).toBe(true);
+    if (findResult.isOk()) {
+      expect(findResult.value.get("name")).toBe("テストDeck");
+    }
+  });
+
+  it("存在しないIDのfindByIdはエラーを返す", async () => {
+    const repository = new MockDeckRepository();
+
+    const result = await repository.findById("nonexistent");
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("findByCreatorは指定した作成者のDeckのみ返す", async () => {
+    const repository = new MockDeckRepository();
+    await repository.create(buildDeck({ id: "1", creatorId: "42" }));
+    await repository.create(buildDeck({ id: "2", creatorId: "42" }));
+    await repository.create(buildDeck({ id: "3", creatorId: "99" }));
+
+    const result = await repository.findByCreator("42");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.items).toHaveLength(2);
+      expect(result.value.totalCount).toBe(2);
+    }
+  });
+
+  it("updateは指定フィールドのみ更新する", async () => {
+    const repository = new MockDeckRepository();
+    await repository.create(buildDeck());
+
+    const result = await repository.update("1", { name: "更新後" });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.get("name")).toBe("更新後");
+    }
+  });
+
+  it("存在しないIDのupdateはエラーを返す", async () => {
+    const repository = new MockDeckRepository();
+
+    const result = await repository.update("nonexistent", { name: "x" });
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("deleteは対象を削除する", async () => {
+    const repository = new MockDeckRepository();
+    await repository.create(buildDeck());
+
+    const deleteResult = await repository.delete("1");
+    expect(deleteResult.isOk()).toBe(true);
+
+    const findResult = await repository.findById("1");
+    expect(findResult.isErr()).toBe(true);
+  });
+});

--- a/api/src/contexts/quiz-learning/infrastructure/repositories/MockDeckRepository.ts
+++ b/api/src/contexts/quiz-learning/infrastructure/repositories/MockDeckRepository.ts
@@ -1,0 +1,99 @@
+import { errAsync, okAsync, type ResultAsync } from "neverthrow";
+import {
+  type RepositoryError,
+  RepositoryErrorFactory,
+} from "../../../../shared/errors";
+import type { Deck, DeckData } from "../../domain/entities/deck/Deck";
+import type { IDeckRepository } from "../../domain/repositories/IDeckRepository";
+
+const ENTITY_NAME = "Deck";
+
+/**
+ * テスト・開発環境向けのDeckリポジトリのin-memoryモック実装
+ *
+ * quiz-managementのMockQuizRepositoryと同じ役割を担う。
+ */
+export class MockDeckRepository implements IDeckRepository {
+  private readonly store = new Map<string, Deck>();
+
+  create(deck: Deck): ResultAsync<Deck, RepositoryError> {
+    this.store.set(deck.get("id"), deck);
+    return okAsync(deck);
+  }
+
+  findById(id: string): ResultAsync<Deck, RepositoryError> {
+    const deck = this.store.get(id);
+    if (deck === undefined) {
+      return errAsync(
+        RepositoryErrorFactory.findFailed(
+          ENTITY_NAME,
+          new Error(`Deck not found: ${id}`),
+        ),
+      );
+    }
+    return okAsync(deck);
+  }
+
+  findByCreator(
+    creatorId: string,
+    options: { limit?: number; offset?: number } = {},
+  ): ResultAsync<
+    { items: Deck[]; totalCount: number; hasMore: boolean },
+    RepositoryError
+  > {
+    const limit = options.limit ?? 20;
+    const offset = options.offset ?? 0;
+
+    const filtered = [...this.store.values()].filter(
+      (deck) => deck.get("creatorId") === creatorId,
+    );
+    const totalCount = filtered.length;
+    const items = filtered.slice(offset, offset + limit);
+    const hasMore = offset + limit < totalCount;
+
+    return okAsync({ items, totalCount, hasMore });
+  }
+
+  update(
+    id: string,
+    patch: Partial<DeckData>,
+  ): ResultAsync<Deck, RepositoryError> {
+    const existing = this.store.get(id);
+    if (existing === undefined) {
+      return errAsync(
+        RepositoryErrorFactory.updateFailed(
+          ENTITY_NAME,
+          new Error(`Deck not found: ${id}`),
+        ),
+      );
+    }
+
+    const updateResult = existing.with(patch);
+    if (updateResult.isErr()) {
+      return errAsync(
+        RepositoryErrorFactory.updateFailed(
+          ENTITY_NAME,
+          new Error(
+            `Failed to apply patch: ${updateResult.error.issues.map((issue) => issue.message).join(", ")}`,
+          ),
+        ),
+      );
+    }
+
+    this.store.set(id, updateResult.value);
+    return okAsync(updateResult.value);
+  }
+
+  delete(id: string): ResultAsync<void, RepositoryError> {
+    if (!this.store.has(id)) {
+      return errAsync(
+        RepositoryErrorFactory.deleteFailed(
+          ENTITY_NAME,
+          new Error(`Deck not found: ${id}`),
+        ),
+      );
+    }
+    this.store.delete(id);
+    return okAsync(undefined);
+  }
+}

--- a/api/src/contexts/quiz-learning/presentation/controllers/DeckController.spec.ts
+++ b/api/src/contexts/quiz-learning/presentation/controllers/DeckController.spec.ts
@@ -1,0 +1,145 @@
+import { errAsync, okAsync } from "neverthrow";
+import { describe, expect, it, vi } from "vitest";
+import { DeckNotFoundError } from "../../domain/errors";
+import { DeckController } from "./DeckController";
+
+const createRequest = (body?: unknown) => {
+  const req = {
+    json: vi.fn().mockResolvedValue(body),
+    param: vi.fn().mockReturnValue("1"),
+    query: vi.fn().mockReturnValue(undefined),
+  };
+  return req;
+};
+
+const createContext = (options: {
+  body?: unknown;
+  userFingerprint?: string;
+}) => {
+  const req = createRequest(options.body);
+  const json = vi.fn((data: unknown, status?: number) => ({
+    data,
+    status: status ?? 200,
+  }));
+  const body = vi.fn((data: unknown, status?: number) => ({
+    data,
+    status: status ?? 200,
+  }));
+  const c = {
+    req,
+    var: { userFingerprint: options.userFingerprint ?? "fp-1" },
+    json,
+    body,
+  };
+  return c as unknown as Parameters<DeckController["createDeck"]>[0] & {
+    json: typeof json;
+    body: typeof body;
+    req: typeof req;
+  };
+};
+
+const createUseCaseStubs = () => ({
+  createDeckUseCase: { execute: vi.fn() },
+  createDeckFromSearchUseCase: { execute: vi.fn() },
+  createDeckFromWrongAnswersUseCase: { execute: vi.fn() },
+  getDeckUseCase: { execute: vi.fn() },
+  getMyDecksUseCase: { execute: vi.fn() },
+  updateDeckUseCase: { execute: vi.fn() },
+  deleteDeckUseCase: { execute: vi.fn() },
+});
+
+const buildController = (stubs: ReturnType<typeof createUseCaseStubs>) =>
+  new DeckController(
+    stubs.createDeckUseCase as never,
+    stubs.createDeckFromSearchUseCase as never,
+    stubs.createDeckFromWrongAnswersUseCase as never,
+    stubs.getDeckUseCase as never,
+    stubs.getMyDecksUseCase as never,
+    stubs.updateDeckUseCase as never,
+    stubs.deleteDeckUseCase as never,
+  );
+
+describe("DeckController", () => {
+  describe("createDeck", () => {
+    it("成功時は200でdeckをラップして返す", async () => {
+      const stubs = createUseCaseStubs();
+      stubs.createDeckUseCase.execute.mockReturnValue(
+        okAsync({ id: "1", name: "テストDeck" }),
+      );
+      const controller = buildController(stubs);
+      const c = createContext({
+        body: { quizIds: ["quiz-1"], source: "manual_selection" },
+        userFingerprint: "fp-42",
+      });
+
+      const response = await controller.createDeck(c);
+
+      expect(response).toEqual({
+        data: { deck: { id: "1", name: "テストDeck" } },
+        status: 200,
+      });
+      expect(stubs.createDeckUseCase.execute).toHaveBeenCalledWith(
+        expect.objectContaining({ creatorFingerprint: "fp-42" }),
+      );
+    });
+
+    it("バリデーション失敗時はUseCaseを呼ばずエラーを返す", async () => {
+      const stubs = createUseCaseStubs();
+      const controller = buildController(stubs);
+      const c = createContext({ body: { quizIds: [] } });
+
+      const response = await controller.createDeck(c);
+
+      expect(stubs.createDeckUseCase.execute).not.toHaveBeenCalled();
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("getDeck", () => {
+    it("成功時はDeckWithQuizzesをそのまま返す", async () => {
+      const stubs = createUseCaseStubs();
+      stubs.getDeckUseCase.execute.mockReturnValue(
+        okAsync({ id: "1", quizzes: [] }),
+      );
+      const controller = buildController(stubs);
+      const c = createContext({});
+
+      const response = await controller.getDeck(c);
+
+      expect(response).toEqual({
+        data: { id: "1", quizzes: [] },
+        status: 200,
+      });
+    });
+
+    it("Deckが見つからない場合は404を返す", async () => {
+      const stubs = createUseCaseStubs();
+      stubs.getDeckUseCase.execute.mockReturnValue(
+        errAsync(new DeckNotFoundError("1")),
+      );
+      const controller = buildController(stubs);
+      const c = createContext({});
+
+      const response = await controller.getDeck(c);
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("deleteDeck", () => {
+    it("成功時は204を返す", async () => {
+      const stubs = createUseCaseStubs();
+      stubs.deleteDeckUseCase.execute.mockReturnValue(okAsync(undefined));
+      const controller = buildController(stubs);
+      const c = createContext({ userFingerprint: "fp-42" });
+
+      const response = await controller.deleteDeck(c);
+
+      expect(response).toEqual({ data: null, status: 204 });
+      expect(stubs.deleteDeckUseCase.execute).toHaveBeenCalledWith(
+        "1",
+        "fp-42",
+      );
+    });
+  });
+});

--- a/api/src/contexts/quiz-learning/presentation/controllers/DeckController.ts
+++ b/api/src/contexts/quiz-learning/presentation/controllers/DeckController.ts
@@ -1,0 +1,250 @@
+import type { AppContext } from "../../../../shared/types";
+import { parseJsonSafe, validateWithZod } from "../../../../shared/utils";
+import type {
+  CreateDeckFromSearchUseCase,
+  CreateDeckFromWrongAnswersUseCase,
+  CreateDeckUseCase,
+  DeleteDeckUseCase,
+  GetDeckUseCase,
+  GetMyDecksUseCase,
+  UpdateDeckUseCase,
+} from "../../application/use-cases";
+import { DeckControllerErrorHandler } from "../errors";
+import {
+  createDeckFromSearchSchema,
+  createDeckFromWrongAnswersSchema,
+  createDeckSchema,
+  updateDeckSchema,
+} from "../schemas/deck-request.schema";
+
+const DEFAULT_LIST_LIMIT = 20;
+const DEFAULT_LIST_OFFSET = 0;
+
+/**
+ * Deck管理コントローラー
+ *
+ * Deck（問題集）のCRUD・生成に関するHTTPリクエストを処理する。
+ * 所有者は常に`c.var.userFingerprint`（anonymousSessionミドルウェア）
+ * から取得し、リクエストの`userId`は受け付けない（ADR-0027）。
+ */
+export class DeckController {
+  constructor(
+    private readonly createDeckUseCase: CreateDeckUseCase,
+    private readonly createDeckFromSearchUseCase: CreateDeckFromSearchUseCase,
+    private readonly createDeckFromWrongAnswersUseCase: CreateDeckFromWrongAnswersUseCase,
+    private readonly getDeckUseCase: GetDeckUseCase,
+    private readonly getMyDecksUseCase: GetMyDecksUseCase,
+    private readonly updateDeckUseCase: UpdateDeckUseCase,
+    private readonly deleteDeckUseCase: DeleteDeckUseCase,
+  ) {}
+
+  async createDeck(c: AppContext) {
+    const jsonResult = await parseJsonSafe(c.req);
+    if (jsonResult.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        jsonResult.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    const validationResult = validateWithZod(
+      createDeckSchema,
+      jsonResult.value,
+    );
+    if (validationResult.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        validationResult.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    const body = validationResult.value;
+    const result = await this.createDeckUseCase.execute({
+      quizIds: body.quizIds,
+      creatorFingerprint: c.var.userFingerprint,
+      ...(body.name !== undefined && { name: body.name }),
+      ...(body.description !== undefined && { description: body.description }),
+    });
+
+    if (result.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        result.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    return c.json({ deck: result.value }, 200);
+  }
+
+  async createDeckFromSearch(c: AppContext) {
+    const jsonResult = await parseJsonSafe(c.req);
+    if (jsonResult.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        jsonResult.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    const validationResult = validateWithZod(
+      createDeckFromSearchSchema,
+      jsonResult.value,
+    );
+    if (validationResult.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        validationResult.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    const body = validationResult.value;
+    const result = await this.createDeckFromSearchUseCase.execute({
+      searchQuery: body.searchQuery,
+      maxQuizzes: body.maxQuizzes,
+      creatorFingerprint: c.var.userFingerprint,
+      ...(body.filters !== undefined && { filters: body.filters }),
+      ...(body.name !== undefined && { name: body.name }),
+      ...(body.description !== undefined && { description: body.description }),
+    });
+
+    if (result.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        result.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    return c.json({ deck: result.value }, 200);
+  }
+
+  async createDeckFromWrongAnswers(c: AppContext) {
+    const jsonResult = await parseJsonSafe(c.req);
+    if (jsonResult.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        jsonResult.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    const validationResult = validateWithZod(
+      createDeckFromWrongAnswersSchema,
+      jsonResult.value,
+    );
+    if (validationResult.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        validationResult.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    const body = validationResult.value;
+    const result = await this.createDeckFromWrongAnswersUseCase.execute({
+      maxQuizzes: body.maxQuizzes,
+      sinceDays: body.sinceDays,
+      creatorFingerprint: c.var.userFingerprint,
+      ...(body.name !== undefined && { name: body.name }),
+      ...(body.description !== undefined && { description: body.description }),
+    });
+
+    if (result.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        result.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    return c.json({ deck: result.value }, 200);
+  }
+
+  async getDeck(c: AppContext) {
+    const id = c.req.param("id");
+
+    const result = await this.getDeckUseCase.execute(id);
+
+    if (result.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        result.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    return c.json(result.value);
+  }
+
+  async getMyDecks(c: AppContext) {
+    const limit = Number(c.req.query("limit") ?? DEFAULT_LIST_LIMIT);
+    const offset = Number(c.req.query("offset") ?? DEFAULT_LIST_OFFSET);
+
+    const result = await this.getMyDecksUseCase.execute({
+      creatorFingerprint: c.var.userFingerprint,
+      limit: Number.isFinite(limit) ? limit : DEFAULT_LIST_LIMIT,
+      offset: Number.isFinite(offset) ? offset : DEFAULT_LIST_OFFSET,
+    });
+
+    if (result.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        result.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    return c.json(result.value);
+  }
+
+  async updateDeck(c: AppContext) {
+    const id = c.req.param("id");
+
+    const jsonResult = await parseJsonSafe(c.req);
+    if (jsonResult.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        jsonResult.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    const validationResult = validateWithZod(
+      updateDeckSchema,
+      jsonResult.value,
+    );
+    if (validationResult.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        validationResult.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    const body = validationResult.value;
+    const result = await this.updateDeckUseCase.execute(id, {
+      creatorFingerprint: c.var.userFingerprint,
+      ...(body.name !== undefined && { name: body.name }),
+      ...(body.description !== undefined && { description: body.description }),
+      ...(body.quizIds !== undefined && { quizIds: body.quizIds }),
+    });
+
+    if (result.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        result.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    return c.json(result.value);
+  }
+
+  async deleteDeck(c: AppContext) {
+    const id = c.req.param("id");
+
+    const result = await this.deleteDeckUseCase.execute(
+      id,
+      c.var.userFingerprint,
+    );
+
+    if (result.isErr()) {
+      const errorResponse = DeckControllerErrorHandler.handleError(
+        result.error,
+      );
+      return c.json(errorResponse.response, errorResponse.statusCode);
+    }
+
+    return c.body(null, 204);
+  }
+}

--- a/api/src/contexts/quiz-learning/presentation/controllers/DeckController.ts
+++ b/api/src/contexts/quiz-learning/presentation/controllers/DeckController.ts
@@ -25,7 +25,7 @@ const DEFAULT_LIST_OFFSET = 0;
  *
  * Deck（問題集）のCRUD・生成に関するHTTPリクエストを処理する。
  * 所有者は常に`c.var.userFingerprint`（anonymousSessionミドルウェア）
- * から取得し、リクエストの`userId`は受け付けない（ADR-0027）。
+ * から取得し、リクエストの`userId`は受け付けない（ADR-0028）。
  */
 export class DeckController {
   constructor(

--- a/api/src/contexts/quiz-learning/presentation/errors/controller-errors.ts
+++ b/api/src/contexts/quiz-learning/presentation/errors/controller-errors.ts
@@ -1,0 +1,54 @@
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { AppError } from "../../../../shared/errors";
+
+/**
+ * エラーからHTTPステータスコードへのマッピング
+ */
+export const getHttpStatusFromError = (
+  error: AppError,
+): ContentfulStatusCode => {
+  return error.code as ContentfulStatusCode;
+};
+
+/**
+ * エラーからTypeSpecレスポンス形式への変換
+ */
+export const mapErrorToResponse = (
+  error: AppError,
+): {
+  code: number;
+  message: string;
+  details?: string;
+  requestId?: string;
+  fieldErrors?: unknown;
+} => {
+  const baseResponse = error.toErrorResponse();
+
+  if ("fieldErrors" in error && error.fieldErrors) {
+    return {
+      ...baseResponse,
+      fieldErrors: error.fieldErrors,
+    };
+  }
+
+  return baseResponse;
+};
+
+/**
+ * Deckコントローラーエラーハンドリングユーティリティ
+ *
+ * `DeckUseCaseError`は全て`AppError`のサブクラスのunion型のため、
+ * quiz-managementの`ControllerErrorHandler`のような文字列エラー
+ * マッピングは不要。`parseJsonSafe`/`validateWithZod`が返す
+ * `JsonParseError`/`ValidationError`も`AppError`のサブクラスであり、
+ * 同じハンドラで扱える。
+ */
+// biome-ignore lint/complexity/noStaticOnlyClass: This utility class is intended to be static-only
+export class DeckControllerErrorHandler {
+  static handleError(error: AppError) {
+    return {
+      statusCode: getHttpStatusFromError(error),
+      response: mapErrorToResponse(error),
+    };
+  }
+}

--- a/api/src/contexts/quiz-learning/presentation/errors/index.ts
+++ b/api/src/contexts/quiz-learning/presentation/errors/index.ts
@@ -1,0 +1,1 @@
+export { DeckControllerErrorHandler } from "./controller-errors";

--- a/api/src/contexts/quiz-learning/presentation/routes/learning.routes.spec.ts
+++ b/api/src/contexts/quiz-learning/presentation/routes/learning.routes.spec.ts
@@ -1,0 +1,151 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetMockDeckRepository } from "../../../../infrastructure/repositories/DeckRepositoryFactory";
+import type { AppEnv, CloudflareBindings } from "../../../../shared/types";
+import { learningRoutes } from "./learning.routes";
+
+type DeckDto = { id: string; name: string };
+type CreateDeckResponseDto = { deck: DeckDto };
+
+const createMockEnv = (): CloudflareBindings => ({
+  NODE_ENV: "test",
+  DB: {} as D1Database,
+  ASSETS: {} as Fetcher,
+});
+
+const createApp = () => {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("userFingerprint", "fp-test-user");
+    await next();
+  });
+  app.route("/api/quiz/v1/learning", learningRoutes);
+  return app;
+};
+
+describe("learning.routes", () => {
+  let app: ReturnType<typeof createApp>;
+  let env: CloudflareBindings;
+
+  beforeEach(() => {
+    resetMockDeckRepository();
+    app = createApp();
+    env = createMockEnv();
+  });
+
+  it("POST /decks でDeckを作成しGET /decks/:idで取得できる", async () => {
+    const createRes = await app.request(
+      "/api/quiz/v1/learning/decks",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "テストDeck",
+          quizIds: ["quiz-1"],
+          source: "manual_selection",
+        }),
+      },
+      env,
+    );
+
+    expect(createRes.status).toBe(200);
+    const created = (await createRes.json()) as CreateDeckResponseDto;
+    expect(created.deck.name).toBe("テストDeck");
+
+    const getRes = await app.request(
+      `/api/quiz/v1/learning/decks/${created.deck.id}`,
+      {},
+      env,
+    );
+
+    expect(getRes.status).toBe(200);
+    const fetched = (await getRes.json()) as DeckDto;
+    expect(fetched.name).toBe("テストDeck");
+  });
+
+  it("GET /decks/mine が /decks/:id より優先してマッチする", async () => {
+    const res = await app.request("/api/quiz/v1/learning/decks/mine", {}, env);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty("items");
+  });
+
+  it("存在しないDeckのGETは404を返す", async () => {
+    const res = await app.request(
+      "/api/quiz/v1/learning/decks/nonexistent",
+      {},
+      env,
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("PATCH /decks/:id でDeckを更新できる", async () => {
+    const createRes = await app.request(
+      "/api/quiz/v1/learning/decks",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          quizIds: ["quiz-1"],
+          source: "manual_selection",
+        }),
+      },
+      env,
+    );
+    const created = (await createRes.json()) as CreateDeckResponseDto;
+
+    const patchRes = await app.request(
+      `/api/quiz/v1/learning/decks/${created.deck.id}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "更新後の名前" }),
+      },
+      env,
+    );
+
+    expect(patchRes.status).toBe(200);
+    const updated = (await patchRes.json()) as DeckDto;
+    expect(updated.name).toBe("更新後の名前");
+  });
+
+  it("DELETE /decks/:id でDeckを削除できる", async () => {
+    const createRes = await app.request(
+      "/api/quiz/v1/learning/decks",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          quizIds: ["quiz-1"],
+          source: "manual_selection",
+        }),
+      },
+      env,
+    );
+    const created = (await createRes.json()) as CreateDeckResponseDto;
+
+    const deleteRes = await app.request(
+      `/api/quiz/v1/learning/decks/${created.deck.id}`,
+      { method: "DELETE" },
+      env,
+    );
+
+    expect(deleteRes.status).toBe(204);
+  });
+
+  it("POST /decks/wrong-questions で間違い問題が0件の場合はエラーを返す", async () => {
+    const res = await app.request(
+      "/api/quiz/v1/learning/decks/wrong-questions",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+      env,
+    );
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/api/src/contexts/quiz-learning/presentation/routes/learning.routes.ts
+++ b/api/src/contexts/quiz-learning/presentation/routes/learning.routes.ts
@@ -20,7 +20,7 @@ import { DeckController } from "../controllers/DeckController";
 // Quiz Learning ルーティング（Deck管理のみ。Session/Answerは次issueのスコープ）
 export const learningRoutes = new Hono<AppEnv>();
 
-// search.routes.tsと同じくMockSearchRepositoryを直接使用（issue #48でD1化予定、ADR-0027参照）
+// search.routes.tsと同じくMockSearchRepositoryを直接使用（issue #48でD1化予定、ADR-0028参照）
 const searchQuizzesUseCase = new SearchQuizzesUseCase(
   new MockSearchRepository(),
 );

--- a/api/src/contexts/quiz-learning/presentation/routes/learning.routes.ts
+++ b/api/src/contexts/quiz-learning/presentation/routes/learning.routes.ts
@@ -1,0 +1,118 @@
+import { Hono } from "hono";
+import { createUserIdentityResolver } from "../../../../infrastructure/identity/UserIdentityResolverFactory";
+import { createAttemptQueryRepository } from "../../../../infrastructure/repositories/AttemptQueryRepositoryFactory";
+import { createDeckRepository } from "../../../../infrastructure/repositories/DeckRepositoryFactory";
+import { createQuizRepository } from "../../../../infrastructure/repositories/QuizRepositoryFactory";
+import type { AppEnv, CloudflareBindings } from "../../../../shared/types";
+import { SearchQuizzesUseCase } from "../../../search/application/use-cases/SearchQuizzesUseCase";
+import { MockSearchRepository } from "../../../search/infrastructure/repositories/MockSearchRepository";
+import {
+  CreateDeckFromSearchUseCase,
+  CreateDeckFromWrongAnswersUseCase,
+  CreateDeckUseCase,
+  DeleteDeckUseCase,
+  GetDeckUseCase,
+  GetMyDecksUseCase,
+  UpdateDeckUseCase,
+} from "../../application/use-cases";
+import { DeckController } from "../controllers/DeckController";
+
+// Quiz Learning ルーティング（Deck管理のみ。Session/Answerは次issueのスコープ）
+export const learningRoutes = new Hono<AppEnv>();
+
+// search.routes.tsと同じくMockSearchRepositoryを直接使用（issue #48でD1化予定、ADR-0027参照）
+const searchQuizzesUseCase = new SearchQuizzesUseCase(
+  new MockSearchRepository(),
+);
+
+/**
+ * Deckコントローラーのファクトリー関数
+ *
+ * quiz.routes.tsのcreateQuizControllerと同じく、環境に応じたリポジトリを
+ * 使ってリクエストごとにコントローラーを作成する。
+ *
+ * @param env - Cloudflare Workersのバインディング環境変数
+ * @returns 設定済みのDeckController
+ */
+function createDeckController(env: CloudflareBindings): DeckController {
+  const deckRepository = createDeckRepository(env);
+  const identityResolver = createUserIdentityResolver(env);
+  const quizRepository = createQuizRepository(env);
+  const attemptQueryRepository = createAttemptQueryRepository(env);
+
+  const createDeckUseCase = new CreateDeckUseCase(
+    deckRepository,
+    identityResolver,
+  );
+  const createDeckFromSearchUseCase = new CreateDeckFromSearchUseCase(
+    deckRepository,
+    identityResolver,
+    searchQuizzesUseCase,
+  );
+  const createDeckFromWrongAnswersUseCase =
+    new CreateDeckFromWrongAnswersUseCase(
+      deckRepository,
+      identityResolver,
+      attemptQueryRepository,
+    );
+  const getDeckUseCase = new GetDeckUseCase(deckRepository, quizRepository);
+  const getMyDecksUseCase = new GetMyDecksUseCase(
+    deckRepository,
+    identityResolver,
+  );
+  const updateDeckUseCase = new UpdateDeckUseCase(
+    deckRepository,
+    identityResolver,
+  );
+  const deleteDeckUseCase = new DeleteDeckUseCase(
+    deckRepository,
+    identityResolver,
+  );
+
+  return new DeckController(
+    createDeckUseCase,
+    createDeckFromSearchUseCase,
+    createDeckFromWrongAnswersUseCase,
+    getDeckUseCase,
+    getMyDecksUseCase,
+    updateDeckUseCase,
+    deleteDeckUseCase,
+  );
+}
+
+// `/decks/mine`は`/decks/:id`より先に登録し、Honoのルートマッチング順で
+// IDパラメータに`mine`が吸われないようにする
+learningRoutes.get("/decks/mine", (c) => {
+  const controller = createDeckController(c.env);
+  return controller.getMyDecks(c);
+});
+
+learningRoutes.post("/decks", (c) => {
+  const controller = createDeckController(c.env);
+  return controller.createDeck(c);
+});
+
+learningRoutes.post("/decks/from-search", (c) => {
+  const controller = createDeckController(c.env);
+  return controller.createDeckFromSearch(c);
+});
+
+learningRoutes.post("/decks/wrong-questions", (c) => {
+  const controller = createDeckController(c.env);
+  return controller.createDeckFromWrongAnswers(c);
+});
+
+learningRoutes.get("/decks/:id", (c) => {
+  const controller = createDeckController(c.env);
+  return controller.getDeck(c);
+});
+
+learningRoutes.patch("/decks/:id", (c) => {
+  const controller = createDeckController(c.env);
+  return controller.updateDeck(c);
+});
+
+learningRoutes.delete("/decks/:id", (c) => {
+  const controller = createDeckController(c.env);
+  return controller.deleteDeck(c);
+});

--- a/api/src/contexts/quiz-learning/presentation/schemas/deck-request.schema.spec.ts
+++ b/api/src/contexts/quiz-learning/presentation/schemas/deck-request.schema.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDeckFromSearchSchema,
+  createDeckFromWrongAnswersSchema,
+  createDeckSchema,
+  updateDeckSchema,
+} from "./deck-request.schema";
+
+describe("deck-request.schema", () => {
+  describe("createDeckSchema", () => {
+    it("必須フィールドのみで検証を通過する", () => {
+      const result = createDeckSchema.safeParse({
+        quizIds: ["quiz-1"],
+        source: "manual_selection",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maxQuizzes).toBe(100);
+        expect(result.data.shuffleOrder).toBe(false);
+      }
+    });
+
+    it("quizIdsが空配列の場合は拒否する", () => {
+      const result = createDeckSchema.safeParse({
+        quizIds: [],
+        source: "manual_selection",
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("不正なsourceを拒否する", () => {
+      const result = createDeckSchema.safeParse({
+        quizIds: ["quiz-1"],
+        source: "invalid_source",
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("createDeckFromSearchSchema", () => {
+    it("searchQueryのみで検証を通過する", () => {
+      const result = createDeckFromSearchSchema.safeParse({
+        searchQuery: "JavaScript",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maxQuizzes).toBe(50);
+      }
+    });
+
+    it("filtersを含めて検証を通過する", () => {
+      const result = createDeckFromSearchSchema.safeParse({
+        searchQuery: "JavaScript",
+        filters: { tags: ["js"], difficulty: "beginner" },
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.filters?.status).toBe("approved");
+      }
+    });
+
+    it("searchQueryが無い場合は拒否する", () => {
+      const result = createDeckFromSearchSchema.safeParse({});
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("createDeckFromWrongAnswersSchema", () => {
+    it("空オブジェクトでもデフォルト値で検証を通過する", () => {
+      const result = createDeckFromWrongAnswersSchema.safeParse({});
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maxQuizzes).toBe(50);
+        expect(result.data.sinceDays).toBe(30);
+      }
+    });
+  });
+
+  describe("updateDeckSchema", () => {
+    it("空オブジェクトでも検証を通過する（全フィールドoptional）", () => {
+      const result = updateDeckSchema.safeParse({});
+
+      expect(result.success).toBe(true);
+    });
+
+    it("quizIdsが空配列の場合は拒否する", () => {
+      const result = updateDeckSchema.safeParse({ quizIds: [] });
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/api/src/contexts/quiz-learning/presentation/schemas/deck-request.schema.ts
+++ b/api/src/contexts/quiz-learning/presentation/schemas/deck-request.schema.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import type { components } from "../../../../shared/types";
+import type { operations } from "../../../../types/generated/api";
+
+/**
+ * Deck新規作成リクエスト用Zodスキーマ（POST /decks）
+ *
+ * `exactOptionalPropertyTypes`下では`.optional()`の出力型が
+ * `T | undefined`になりTypeSpec型（`T?`のみ）と不一致になるため、
+ * `.transform()`でundefinedフィールドをキーごと除去する
+ * （`shared/schemas/quiz.schema.ts`と同じ対処パターン）。
+ */
+export const createDeckSchema = z
+  .object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    quizIds: z.array(z.string()).min(1),
+    source: z.enum(["manual_selection", "search_result", "wrong_questions"]),
+    sourceQuery: z.string().optional(),
+    maxQuizzes: z.coerce.number().int().min(1).default(100),
+    shuffleOrder: z.coerce.boolean().default(false),
+  })
+  .transform((data) => ({
+    quizIds: data.quizIds,
+    source: data.source,
+    maxQuizzes: data.maxQuizzes,
+    shuffleOrder: data.shuffleOrder,
+    ...(data.name !== undefined && { name: data.name }),
+    ...(data.description !== undefined && { description: data.description }),
+    ...(data.sourceQuery !== undefined && {
+      sourceQuery: data.sourceQuery,
+    }),
+  })) satisfies z.ZodType<components["schemas"]["CreateDeckRequest"]>;
+
+const quizSearchFiltersSchema = z
+  .object({
+    tags: z.array(z.string()).optional(),
+    difficulty: z.string().optional(),
+    answerType: z
+      .enum(["boolean", "free_text", "single_choice", "multiple_choice"])
+      .optional(),
+    status: z
+      .enum(["pending_approval", "approved", "rejected"])
+      .default("approved"),
+    creatorId: z.string().optional(),
+  })
+  .transform((data) => ({
+    status: data.status,
+    ...(data.tags !== undefined && { tags: data.tags }),
+    ...(data.difficulty !== undefined && { difficulty: data.difficulty }),
+    ...(data.answerType !== undefined && { answerType: data.answerType }),
+    ...(data.creatorId !== undefined && { creatorId: data.creatorId }),
+  })) satisfies z.ZodType<components["schemas"]["QuizSearchFilters"]>;
+
+/**
+ * 検索結果からDeck生成リクエスト用Zodスキーマ（POST /decks/from-search）
+ */
+export const createDeckFromSearchSchema = z
+  .object({
+    searchQuery: z.string(),
+    filters: quizSearchFiltersSchema.optional(),
+    maxQuizzes: z.coerce.number().int().min(1).default(50),
+    name: z.string().optional(),
+    description: z.string().optional(),
+  })
+  .transform((data) => ({
+    searchQuery: data.searchQuery,
+    maxQuizzes: data.maxQuizzes,
+    ...(data.filters !== undefined && { filters: data.filters }),
+    ...(data.name !== undefined && { name: data.name }),
+    ...(data.description !== undefined && { description: data.description }),
+  })) satisfies z.ZodType<components["schemas"]["CreateDeckFromSearchRequest"]>;
+
+/**
+ * 間違い問題からDeck生成リクエスト用Zodスキーマ（POST /decks/wrong-questions）
+ *
+ * userIdはTypeSpecから削除済み（ADR-0027）。所有者は常に
+ * `c.var.userFingerprint`から解決する。
+ */
+export const createDeckFromWrongAnswersSchema = z
+  .object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    maxQuizzes: z.coerce.number().int().min(1).default(50),
+    sinceDays: z.coerce.number().int().min(1).default(30),
+  })
+  .transform((data) => ({
+    maxQuizzes: data.maxQuizzes,
+    sinceDays: data.sinceDays,
+    ...(data.name !== undefined && { name: data.name }),
+    ...(data.description !== undefined && { description: data.description }),
+  })) satisfies z.ZodType<
+  operations["QuizLearning_createDeckFromWrongAnswers"]["requestBody"]["content"]["application/json"]
+>;
+
+/**
+ * Deck部分更新リクエスト用Zodスキーマ（PATCH /decks/:id）
+ */
+export const updateDeckSchema = z
+  .object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    quizIds: z.array(z.string()).min(1).optional(),
+  })
+  .transform((data) => ({
+    ...(data.name !== undefined && { name: data.name }),
+    ...(data.description !== undefined && { description: data.description }),
+    ...(data.quizIds !== undefined && { quizIds: data.quizIds }),
+  })) satisfies z.ZodType<components["schemas"]["UpdateDeckRequest"]>;

--- a/api/src/contexts/quiz-learning/presentation/schemas/deck-request.schema.ts
+++ b/api/src/contexts/quiz-learning/presentation/schemas/deck-request.schema.ts
@@ -74,7 +74,7 @@ export const createDeckFromSearchSchema = z
 /**
  * 間違い問題からDeck生成リクエスト用Zodスキーマ（POST /decks/wrong-questions）
  *
- * userIdはTypeSpecから削除済み（ADR-0027）。所有者は常に
+ * userIdはTypeSpecから削除済み（ADR-0028）。所有者は常に
  * `c.var.userFingerprint`から解決する。
  */
 export const createDeckFromWrongAnswersSchema = z

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { learningRoutes } from "./contexts/quiz-learning/presentation/routes/learning.routes";
 import { quizRoutes } from "./contexts/quiz-management/presentation/routes/quiz.routes";
 import { searchRoutes } from "./contexts/search/presentation/routes/search.routes";
 import { anonymousSession } from "./middleware/anonymousSession";
@@ -39,9 +40,11 @@ app.use("*", anonymousSession);
  *
  * クイズ管理関連のルートを /api/quiz/v1/manage パスにマウントします。
  * 検索関連のルートを /api/search/v1 パスにマウントします。
+ * 学習（Deck管理）関連のルートを /api/quiz/v1/learning パスにマウントします。
  */
 app.route("/api/quiz/v1/manage", quizRoutes);
 app.route("/api/search/v1", searchRoutes);
+app.route("/api/quiz/v1/learning", learningRoutes);
 
 /**
  * ヘルスチェックエンドポイント

--- a/api/src/infrastructure/identity/D1UserIdentityResolver.spec.ts
+++ b/api/src/infrastructure/identity/D1UserIdentityResolver.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { D1UserIdentityResolver } from "./D1UserIdentityResolver";
+
+/**
+ * D1PreparedStatementの最小モックを組み立てる
+ *
+ * `SELECT`は`.first()`が呼ばれ、`INSERT`は`.run()`が呼ばれる想定で、
+ * それぞれの戻り値を個別に注入できるようにする。
+ */
+const createMockDb = (options: {
+  first: unknown;
+  run?: { meta: { last_row_id: number } };
+}): D1Database => {
+  const first = vi.fn().mockResolvedValue(options.first);
+  const run = vi
+    .fn()
+    .mockResolvedValue(options.run ?? { meta: { last_row_id: 0 } });
+  const bind = vi.fn().mockReturnValue({ first, run });
+  const prepare = vi.fn().mockReturnValue({ bind });
+
+  return { prepare } as unknown as D1Database;
+};
+
+describe("D1UserIdentityResolver", () => {
+  it("既存のUserIdentityが見つかった場合はそのidを返す", async () => {
+    const db = createMockDb({ first: { id: 42 } });
+    const resolver = new D1UserIdentityResolver(db);
+
+    const result = await resolver.resolve("existing-anonymous-id");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("42");
+    }
+  });
+
+  it("UserIdentityが存在しない場合は新規作成しlast_row_idを返す", async () => {
+    const db = createMockDb({
+      first: null,
+      run: { meta: { last_row_id: 7 } },
+    });
+    const resolver = new D1UserIdentityResolver(db);
+
+    const result = await resolver.resolve("new-anonymous-id");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("7");
+    }
+  });
+
+  it("SELECT失敗時はRepositoryErrorを返す", async () => {
+    const first = vi.fn().mockRejectedValue(new Error("SELECT failed"));
+    const bind = vi.fn().mockReturnValue({ first });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+    const resolver = new D1UserIdentityResolver(db);
+
+    const result = await resolver.resolve("some-id");
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("INSERT失敗時はRepositoryErrorを返す", async () => {
+    const first = vi.fn().mockResolvedValue(null);
+    const run = vi.fn().mockRejectedValue(new Error("INSERT failed"));
+    const bind = vi.fn().mockReturnValue({ first, run });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+    const resolver = new D1UserIdentityResolver(db);
+
+    const result = await resolver.resolve("some-id");
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/api/src/infrastructure/identity/D1UserIdentityResolver.ts
+++ b/api/src/infrastructure/identity/D1UserIdentityResolver.ts
@@ -1,0 +1,58 @@
+import { ResultAsync } from "neverthrow";
+import {
+  type RepositoryError,
+  RepositoryErrorFactory,
+} from "../../shared/errors";
+import type { IUserIdentityResolver } from "../../shared/identity/IUserIdentityResolver";
+
+const ENTITY_NAME = "UserIdentity";
+
+/**
+ * D1（`UserIdentity`テーブル）を用いた匿名ユーザー識別解決の実装
+ *
+ * `anonymous_id`（`userFingerprint`）で`UserIdentity`を検索し、
+ * 存在しなければ新規作成する（find-or-create）。D1QuizRepositoryと
+ * 同じ`ResultAsync.fromPromise` + `RepositoryErrorFactory`パターンに従う。
+ */
+export class D1UserIdentityResolver implements IUserIdentityResolver {
+  constructor(private readonly db: D1Database) {}
+
+  resolve(anonymousId: string): ResultAsync<string, RepositoryError> {
+    return this.findByAnonymousId(anonymousId).andThen((existingId) => {
+      if (existingId !== null) {
+        return ResultAsync.fromSafePromise(Promise.resolve(existingId));
+      }
+      return this.create(anonymousId);
+    });
+  }
+
+  private findByAnonymousId(
+    anonymousId: string,
+  ): ResultAsync<string | null, RepositoryError> {
+    return ResultAsync.fromPromise(
+      this.db
+        .prepare("SELECT id FROM UserIdentity WHERE anonymous_id = ?")
+        .bind(anonymousId)
+        .first<{ id: number }>(),
+      (error) =>
+        RepositoryErrorFactory.findFailed(
+          ENTITY_NAME,
+          error instanceof Error ? error : new Error("Unknown find error"),
+        ),
+    ).map((row) => (row === null ? null : String(row.id)));
+  }
+
+  private create(anonymousId: string): ResultAsync<string, RepositoryError> {
+    return ResultAsync.fromPromise(
+      this.db
+        .prepare("INSERT INTO UserIdentity (anonymous_id) VALUES (?)")
+        .bind(anonymousId)
+        .run(),
+      (error) =>
+        RepositoryErrorFactory.createFailed(
+          ENTITY_NAME,
+          error instanceof Error ? error : new Error("Unknown create error"),
+        ),
+    ).map((result) => String(result.meta.last_row_id));
+  }
+}

--- a/api/src/infrastructure/identity/MockUserIdentityResolver.spec.ts
+++ b/api/src/infrastructure/identity/MockUserIdentityResolver.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { MockUserIdentityResolver } from "./MockUserIdentityResolver";
+
+describe("MockUserIdentityResolver", () => {
+  it("同じanonymousIdを渡すと同じ識別子を返す", async () => {
+    const resolver = new MockUserIdentityResolver();
+    const anonymousId = "550e8400-e29b-41d4-a716-446655440000";
+
+    const first = await resolver.resolve(anonymousId);
+    const second = await resolver.resolve(anonymousId);
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    if (first.isOk() && second.isOk()) {
+      expect(first.value).toBe(second.value);
+    }
+  });
+
+  it("anonymousIdをそのまま識別子として返す（モック環境はINTEGER FK制約を持たないため）", async () => {
+    const resolver = new MockUserIdentityResolver();
+    const anonymousId = "550e8400-e29b-41d4-a716-446655440000";
+
+    const result = await resolver.resolve(anonymousId);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(anonymousId);
+    }
+  });
+
+  it("異なるanonymousIdには異なる識別子を返す", async () => {
+    const resolver = new MockUserIdentityResolver();
+
+    const first = await resolver.resolve("user-a");
+    const second = await resolver.resolve("user-b");
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    if (first.isOk() && second.isOk()) {
+      expect(first.value).not.toBe(second.value);
+    }
+  });
+});

--- a/api/src/infrastructure/identity/MockUserIdentityResolver.ts
+++ b/api/src/infrastructure/identity/MockUserIdentityResolver.ts
@@ -1,0 +1,16 @@
+import { okAsync, type ResultAsync } from "neverthrow";
+import type { RepositoryError } from "../../shared/errors";
+import type { IUserIdentityResolver } from "../../shared/identity/IUserIdentityResolver";
+
+/**
+ * テスト・開発環境向けの匿名ユーザー識別解決モック実装
+ *
+ * モック環境はD1のINTEGER FK制約を持たないため、`anonymous_id`から
+ * `UserIdentity.id`を採番する必要がない。単純化のため、fingerprint
+ * （anonymousId）自体をそのまま識別子として返す。
+ */
+export class MockUserIdentityResolver implements IUserIdentityResolver {
+  resolve(anonymousId: string): ResultAsync<string, RepositoryError> {
+    return okAsync(anonymousId);
+  }
+}

--- a/api/src/infrastructure/identity/UserIdentityResolverFactory.test.ts
+++ b/api/src/infrastructure/identity/UserIdentityResolverFactory.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { CloudflareBindings } from "../../shared/types";
+import { D1UserIdentityResolver } from "./D1UserIdentityResolver";
+import { MockUserIdentityResolver } from "./MockUserIdentityResolver";
+import { createUserIdentityResolver } from "./UserIdentityResolverFactory";
+
+const createMockEnv = (
+  overrides: Partial<CloudflareBindings> = {},
+): CloudflareBindings => {
+  const baseEnv: CloudflareBindings = {
+    NODE_ENV: "development",
+    DB: {} as D1Database,
+    ASSETS: {} as Fetcher,
+  };
+  return { ...baseEnv, ...overrides };
+};
+
+describe("createUserIdentityResolver", () => {
+  const testCases = [
+    {
+      description: "テスト環境ではMockUserIdentityResolverを返す",
+      env: createMockEnv({ NODE_ENV: "test" }),
+      expectedType: MockUserIdentityResolver,
+    },
+    {
+      description:
+        "本番環境でUSE_MOCK_DB未設定の場合D1UserIdentityResolverを返す",
+      env: createMockEnv({ NODE_ENV: "production" }),
+      expectedType: D1UserIdentityResolver,
+    },
+    {
+      description:
+        "開発環境でUSE_MOCK_DB=falseの場合D1UserIdentityResolverを返す",
+      env: createMockEnv({ NODE_ENV: "development", USE_MOCK_DB: "false" }),
+      expectedType: D1UserIdentityResolver,
+    },
+  ];
+
+  testCases.forEach(({ description, env, expectedType }) => {
+    it(description, () => {
+      const resolver = createUserIdentityResolver(env);
+      expect(resolver).toBeInstanceOf(expectedType);
+    });
+  });
+});

--- a/api/src/infrastructure/identity/UserIdentityResolverFactory.ts
+++ b/api/src/infrastructure/identity/UserIdentityResolverFactory.ts
@@ -1,0 +1,23 @@
+import type { IUserIdentityResolver } from "../../shared/identity/IUserIdentityResolver";
+import type { CloudflareBindings } from "../../shared/types";
+import { shouldUseMock } from "../repositories/QuizRepositoryFactory";
+import { D1UserIdentityResolver } from "./D1UserIdentityResolver";
+import { MockUserIdentityResolver } from "./MockUserIdentityResolver";
+
+/**
+ * 匿名ユーザー識別解決リゾルバーファクトリー
+ *
+ * `QuizRepositoryFactory`と同じ`shouldUseMock`判定ロジックを再利用し、
+ * D1/Mockを切替える。
+ *
+ * @param env - Cloudflare Workersのバインディング環境変数
+ * @returns 適切な`IUserIdentityResolver`実装
+ */
+export function createUserIdentityResolver(
+  env: CloudflareBindings,
+): IUserIdentityResolver {
+  if (shouldUseMock(env)) {
+    return new MockUserIdentityResolver();
+  }
+  return new D1UserIdentityResolver(env.DB);
+}

--- a/api/src/infrastructure/repositories/AttemptQueryRepositoryFactory.test.ts
+++ b/api/src/infrastructure/repositories/AttemptQueryRepositoryFactory.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { D1AttemptQueryRepository } from "../../contexts/quiz-learning/infrastructure/repositories/D1AttemptQueryRepository";
+import { MockAttemptQueryRepository } from "../../contexts/quiz-learning/infrastructure/repositories/MockAttemptQueryRepository";
+import type { CloudflareBindings } from "../../shared/types";
+import { createAttemptQueryRepository } from "./AttemptQueryRepositoryFactory";
+
+const createMockEnv = (
+  overrides: Partial<CloudflareBindings> = {},
+): CloudflareBindings => {
+  const baseEnv: CloudflareBindings = {
+    NODE_ENV: "development",
+    DB: {} as D1Database,
+    ASSETS: {} as Fetcher,
+  };
+  return { ...baseEnv, ...overrides };
+};
+
+describe("createAttemptQueryRepository", () => {
+  const testCases = [
+    {
+      description: "テスト環境ではMockAttemptQueryRepositoryを返す",
+      env: createMockEnv({ NODE_ENV: "test" }),
+      expectedType: MockAttemptQueryRepository,
+    },
+    {
+      description:
+        "本番環境でUSE_MOCK_DB未設定の場合D1AttemptQueryRepositoryを返す",
+      env: createMockEnv({ NODE_ENV: "production" }),
+      expectedType: D1AttemptQueryRepository,
+    },
+  ];
+
+  testCases.forEach(({ description, env, expectedType }) => {
+    it(description, () => {
+      const repository = createAttemptQueryRepository(env);
+      expect(repository).toBeInstanceOf(expectedType);
+    });
+  });
+});

--- a/api/src/infrastructure/repositories/AttemptQueryRepositoryFactory.ts
+++ b/api/src/infrastructure/repositories/AttemptQueryRepositoryFactory.ts
@@ -1,0 +1,23 @@
+import type { IAttemptQueryRepository } from "../../contexts/quiz-learning/domain/repositories/IAttemptQueryRepository";
+import { D1AttemptQueryRepository } from "../../contexts/quiz-learning/infrastructure/repositories/D1AttemptQueryRepository";
+import { MockAttemptQueryRepository } from "../../contexts/quiz-learning/infrastructure/repositories/MockAttemptQueryRepository";
+import type { CloudflareBindings } from "../../shared/types";
+import { shouldUseMock } from "./QuizRepositoryFactory";
+
+/**
+ * 間違い問題クエリリポジトリファクトリー
+ *
+ * QuizRepositoryFactoryと同じ`shouldUseMock`判定ロジックを再利用し、
+ * D1/Mockを切替える。
+ *
+ * @param env - Cloudflare Workersのバインディング環境変数
+ * @returns 適切なリポジトリ実装
+ */
+export function createAttemptQueryRepository(
+  env: CloudflareBindings,
+): IAttemptQueryRepository {
+  if (shouldUseMock(env)) {
+    return new MockAttemptQueryRepository();
+  }
+  return new D1AttemptQueryRepository(env.DB);
+}

--- a/api/src/infrastructure/repositories/DeckRepositoryFactory.test.ts
+++ b/api/src/infrastructure/repositories/DeckRepositoryFactory.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { D1DeckRepository } from "../../contexts/quiz-learning/infrastructure/repositories/D1DeckRepository";
+import { MockDeckRepository } from "../../contexts/quiz-learning/infrastructure/repositories/MockDeckRepository";
+import type { CloudflareBindings } from "../../shared/types";
+import { createDeckRepository } from "./DeckRepositoryFactory";
+
+const createMockEnv = (
+  overrides: Partial<CloudflareBindings> = {},
+): CloudflareBindings => {
+  const baseEnv: CloudflareBindings = {
+    NODE_ENV: "development",
+    DB: {} as D1Database,
+    ASSETS: {} as Fetcher,
+  };
+  return { ...baseEnv, ...overrides };
+};
+
+describe("createDeckRepository", () => {
+  const testCases = [
+    {
+      description: "テスト環境ではMockDeckRepositoryを返す",
+      env: createMockEnv({ NODE_ENV: "test" }),
+      expectedType: MockDeckRepository,
+    },
+    {
+      description: "本番環境でUSE_MOCK_DB未設定の場合D1DeckRepositoryを返す",
+      env: createMockEnv({ NODE_ENV: "production" }),
+      expectedType: D1DeckRepository,
+    },
+    {
+      description: "開発環境でUSE_MOCK_DB=falseの場合D1DeckRepositoryを返す",
+      env: createMockEnv({ NODE_ENV: "development", USE_MOCK_DB: "false" }),
+      expectedType: D1DeckRepository,
+    },
+  ];
+
+  testCases.forEach(({ description, env, expectedType }) => {
+    it(description, () => {
+      const repository = createDeckRepository(env);
+      expect(repository).toBeInstanceOf(expectedType);
+    });
+  });
+});

--- a/api/src/infrastructure/repositories/DeckRepositoryFactory.ts
+++ b/api/src/infrastructure/repositories/DeckRepositoryFactory.ts
@@ -5,6 +5,17 @@ import type { CloudflareBindings } from "../../shared/types";
 import { shouldUseMock } from "./QuizRepositoryFactory";
 
 /**
+ * モック環境（テスト・開発）向けのMockDeckRepositoryシングルトン
+ *
+ * Cloudflare Workersはリクエストごとにハンドラーが呼ばれ、その都度
+ * `createDeckRepository`が呼ばれる。`new MockDeckRepository()`を
+ * 毎回生成すると、モック環境ではリクエストを跨いだデータ永続性が
+ * 失われ、「作成した直後のGETが404になる」実用上の問題が生じる。
+ * モジュールスコープで使い回すことでモック環境でもデータを保持する。
+ */
+let mockDeckRepository: MockDeckRepository | undefined;
+
+/**
  * Deckリポジトリファクトリー
  *
  * QuizRepositoryFactoryと同じ`shouldUseMock`判定ロジックを再利用し、
@@ -15,7 +26,17 @@ import { shouldUseMock } from "./QuizRepositoryFactory";
  */
 export function createDeckRepository(env: CloudflareBindings): IDeckRepository {
   if (shouldUseMock(env)) {
-    return new MockDeckRepository();
+    mockDeckRepository ??= new MockDeckRepository();
+    return mockDeckRepository;
   }
   return new D1DeckRepository(env.DB);
+}
+
+/**
+ * テスト用: MockDeckRepositoryシングルトンをリセットする
+ *
+ * テスト間でDeckデータが漏れないよう、`beforeEach`等で呼び出す想定。
+ */
+export function resetMockDeckRepository(): void {
+  mockDeckRepository = undefined;
 }

--- a/api/src/infrastructure/repositories/DeckRepositoryFactory.ts
+++ b/api/src/infrastructure/repositories/DeckRepositoryFactory.ts
@@ -1,0 +1,21 @@
+import type { IDeckRepository } from "../../contexts/quiz-learning/domain/repositories/IDeckRepository";
+import { D1DeckRepository } from "../../contexts/quiz-learning/infrastructure/repositories/D1DeckRepository";
+import { MockDeckRepository } from "../../contexts/quiz-learning/infrastructure/repositories/MockDeckRepository";
+import type { CloudflareBindings } from "../../shared/types";
+import { shouldUseMock } from "./QuizRepositoryFactory";
+
+/**
+ * Deckリポジトリファクトリー
+ *
+ * QuizRepositoryFactoryと同じ`shouldUseMock`判定ロジックを再利用し、
+ * D1/Mockを切替える。
+ *
+ * @param env - Cloudflare Workersのバインディング環境変数
+ * @returns 適切なリポジトリ実装
+ */
+export function createDeckRepository(env: CloudflareBindings): IDeckRepository {
+  if (shouldUseMock(env)) {
+    return new MockDeckRepository();
+  }
+  return new D1DeckRepository(env.DB);
+}

--- a/api/src/shared/identity/IUserIdentityResolver.ts
+++ b/api/src/shared/identity/IUserIdentityResolver.ts
@@ -10,7 +10,7 @@ import type { RepositoryError } from "../errors";
  * （INTEGER PRIMARY KEY）への外部キーを持つ。両者を橋渡しする役割を担う。
  *
  * ミドルウェア本体には統合せず独立したポートとして定義した理由は
- * ADR-0027 を参照。
+ * ADR-0028 を参照。
  */
 export interface IUserIdentityResolver {
   /**

--- a/api/src/shared/identity/IUserIdentityResolver.ts
+++ b/api/src/shared/identity/IUserIdentityResolver.ts
@@ -1,0 +1,26 @@
+import type { ResultAsync } from "neverthrow";
+import type { RepositoryError } from "../errors";
+
+/**
+ * 匿名ユーザー識別子（`userFingerprint` / `UserIdentity.anonymous_id`）を
+ * 永続化された `UserIdentity.id` に解決するポート
+ *
+ * `anonymousSession` ミドルウェア（ADR-0026）が発行する `userFingerprint` は
+ * UUID文字列だが、D1上の集約（`Deck.creator_id` 等）は `UserIdentity.id`
+ * （INTEGER PRIMARY KEY）への外部キーを持つ。両者を橋渡しする役割を担う。
+ *
+ * ミドルウェア本体には統合せず独立したポートとして定義した理由は
+ * ADR-0027 を参照。
+ */
+export interface IUserIdentityResolver {
+  /**
+   * 匿名識別子から永続化済みの `UserIdentity.id`（文字列化）を解決する
+   *
+   * 該当する `UserIdentity` が存在しない場合は新規作成した上でIDを返す
+   * （find-or-create）。
+   *
+   * @param anonymousId - `userFingerprint`（UUID v4文字列）
+   * @returns 解決された `UserIdentity.id`（文字列化）またはエラー
+   */
+  resolve(anonymousId: string): ResultAsync<string, RepositoryError>;
+}

--- a/api/src/types/generated/api.d.ts
+++ b/api/src/types/generated/api.d.ts
@@ -87,7 +87,8 @@ export interface paths {
     delete: operations["QuizLearning_deleteDeck"];
     options?: never;
     head?: never;
-    patch?: never;
+    /** @description Update deck (partial update) */
+    patch: operations["QuizLearning_updateDeck"];
     trace?: never;
   };
   "/api/quiz/v1/learning/published": {
@@ -884,7 +885,7 @@ export interface components {
     };
     DeckId: string;
     DeckListResponse: {
-      items: components["schemas"]["DeckWithQuizzes"][];
+      items: components["schemas"]["Deck"][];
       /** Format: int32 */
       totalCount: number;
       hasMore: boolean;
@@ -1367,6 +1368,11 @@ export interface components {
       components["schemas"]["ErrorResponse"],
       "code" | "message"
     >;
+    UpdateDeckRequest: {
+      name?: string;
+      description?: string;
+      quizIds?: components["schemas"]["QuizId"][];
+    };
     /** @example {
      *       "question": "HTMLの段落を表すタグはどれですか？（修正版）",
      *       "answerType": "single_choice",
@@ -1533,9 +1539,7 @@ export interface operations {
   };
   QuizLearning_getMyDecks: {
     parameters: {
-      query: {
-        userId: components["schemas"]["UserId"];
-      };
+      query?: never;
       header?: never;
       path?: never;
       cookie?: never;
@@ -1569,7 +1573,6 @@ export interface operations {
         "application/json": {
           name?: string;
           description?: string;
-          userId: components["schemas"]["UserId"];
           /**
            * Format: int32
            * @default 50
@@ -1662,6 +1665,44 @@ export interface operations {
           "application/json":
             | components["schemas"]["NotFoundError"]
             | components["schemas"]["ForbiddenError"];
+        };
+      };
+    };
+  };
+  QuizLearning_updateDeck: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: components["schemas"]["DeckId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateDeckRequest"];
+      };
+    };
+    responses: {
+      /** @description The request has succeeded. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Deck"];
+        };
+      };
+      /** @description An unexpected error response. */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["NotFoundError"]
+            | components["schemas"]["ForbiddenError"]
+            | components["schemas"]["ValidationError"];
         };
       };
     };

--- a/api/tests/features/deck-management.spec.ts
+++ b/api/tests/features/deck-management.spec.ts
@@ -2,7 +2,7 @@ import { spec } from "pactum";
 import { deckManagementData } from "../fixtures/deck-management-data";
 
 // Deck Management BDD Tests - Deck管理BDDテスト
-// issue #47（quiz-learning Deck管理）/ ADR-0027
+// issue #47（quiz-learning Deck管理）/ ADR-0028
 // Endpoint: /api/quiz/v1/learning/decks/*
 //
 // dev-mock env（USE_MOCK_DB=true）で動作するため、MockDeckRepository /

--- a/api/tests/features/deck-management.spec.ts
+++ b/api/tests/features/deck-management.spec.ts
@@ -1,0 +1,220 @@
+import { spec } from "pactum";
+import { deckManagementData } from "../fixtures/deck-management-data";
+
+// Deck Management BDD Tests - Deck管理BDDテスト
+// issue #47（quiz-learning Deck管理）/ ADR-0027
+// Endpoint: /api/quiz/v1/learning/decks/*
+//
+// dev-mock env（USE_MOCK_DB=true）で動作するため、MockDeckRepository /
+// MockUserIdentityResolver / MockSearchRepository / MockAttemptQueryRepository
+// を経由する。所有者はanonymousSessionミドルウェアが発行するCookie
+// （userFingerprint）で識別される。
+
+const BASE_PATH = "/api/quiz/v1/learning/decks";
+const COOKIE_NAME = "quiz_fingerprint";
+
+describe("Deck管理: Deck management", () => {
+  describe("Deck新規作成: POST /decks", () => {
+    deckManagementData.createDeckScenarios.forEach((testCase) => {
+      it(`Deckを作成できる: ${testCase.description}`, async () => {
+        // Given: 有効なDeck作成リクエスト
+
+        // When: POST /decksでDeckを作成
+        const response = await spec()
+          .post(BASE_PATH)
+          .withJson(testCase.requestBody)
+          .expectStatus(200);
+
+        // Then: 作成されたDeckが返る
+        const body = response.json;
+        expect(body).toHaveProperty("deck");
+        expect(body.deck).toHaveProperty("id");
+        expect(body.deck.quizIds).toEqual(testCase.requestBody.quizIds);
+      });
+    });
+
+    it("quizIdsが空の場合は400を返す", async () => {
+      // Given: quizIdsが空のリクエスト
+
+      // When: POST /decksを実行
+      const response = await spec()
+        .post(BASE_PATH)
+        .withJson({ quizIds: [], source: "manual_selection" })
+        .expectStatus(400);
+
+      // Then: バリデーションエラーが返る
+      expect(response.json).toHaveProperty("code");
+    });
+  });
+
+  describe("Deck取得〜削除ワークフロー: GET/PATCH/DELETE /decks/:id", () => {
+    it("作成したDeckを取得・更新・削除できる", async () => {
+      // Given: 新規Deckを作成（Cookie無しの匿名アクセスは毎回別UUIDが
+      // 発行されるため、後続のPATCH/DELETEで所有者不一致にならないよう
+      // 固定fingerprintを明示する）
+      const fingerprint = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+      const createResponse = await spec()
+        .post(BASE_PATH)
+        .withCookies(COOKIE_NAME, fingerprint)
+        .withJson({
+          name: "ワークフローDeck",
+          quizIds: ["quiz-1", "quiz-2"],
+          source: "manual_selection",
+        })
+        .expectStatus(200);
+      const deckId = createResponse.json.deck.id;
+
+      // When: GET /decks/:idで取得
+      const getResponse = await spec()
+        .get(`${BASE_PATH}/${deckId}`)
+        .expectStatus(200);
+
+      // Then: 作成したDeckと問題本体（quizzes）が返る
+      expect(getResponse.json.name).toBe("ワークフローDeck");
+      expect(getResponse.json).toHaveProperty("quizzes");
+      expect(getResponse.json).toHaveProperty("totalQuizzes");
+
+      // When: PATCH /decks/:idで更新
+      const patchResponse = await spec()
+        .patch(`${BASE_PATH}/${deckId}`)
+        .withCookies(COOKIE_NAME, fingerprint)
+        .withJson({ name: "更新後のDeck名" })
+        .expectStatus(200);
+
+      // Then: 更新後の名前が返る
+      expect(patchResponse.json.name).toBe("更新後のDeck名");
+
+      // When: DELETE /decks/:idで削除
+      await spec()
+        .delete(`${BASE_PATH}/${deckId}`)
+        .withCookies(COOKIE_NAME, fingerprint)
+        .expectStatus(204);
+
+      // Then: 削除後のGETは404
+      await spec().get(`${BASE_PATH}/${deckId}`).expectStatus(404);
+    });
+
+    it("存在しないDeckのGETは404を返す", async () => {
+      // Given: 存在しないDeck ID
+
+      // When: GET /decks/:idを実行
+      const response = await spec()
+        .get(`${BASE_PATH}/nonexistent-deck-id`)
+        .expectStatus(404);
+
+      // Then: NotFoundErrorが返る
+      expect(response.json).toHaveProperty("code");
+    });
+  });
+
+  describe("所有者制御: Ownership enforcement", () => {
+    it("作成者以外はDeckを更新・削除できない", async () => {
+      // Given: userAが作成したDeck
+      const ownerFingerprint = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+      const createResponse = await spec()
+        .post(BASE_PATH)
+        .withCookies(COOKIE_NAME, ownerFingerprint)
+        .withJson({ quizIds: ["quiz-1"], source: "manual_selection" })
+        .expectStatus(200);
+      const deckId = createResponse.json.deck.id;
+
+      // When: 別のユーザー（userB）がPATCHを試みる
+      const otherFingerprint = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+      const patchResponse = await spec()
+        .patch(`${BASE_PATH}/${deckId}`)
+        .withCookies(COOKIE_NAME, otherFingerprint)
+        .withJson({ name: "乗っ取り" })
+        .expectStatus(403);
+
+      // Then: ForbiddenErrorが返る
+      expect(patchResponse.json).toHaveProperty("code");
+
+      // When: 別のユーザー（userB）がDELETEを試みる
+      const deleteResponse = await spec()
+        .delete(`${BASE_PATH}/${deckId}`)
+        .withCookies(COOKIE_NAME, otherFingerprint)
+        .expectStatus(403);
+
+      // Then: ForbiddenErrorが返る
+      expect(deleteResponse.json).toHaveProperty("code");
+    });
+  });
+
+  describe("自分のDeck一覧: GET /decks/mine", () => {
+    it("作成したDeckが一覧に含まれる", async () => {
+      // Given: 特定ユーザーがDeckを作成
+      const fingerprint = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+      const createResponse = await spec()
+        .post(BASE_PATH)
+        .withCookies(COOKIE_NAME, fingerprint)
+        .withJson({
+          name: "一覧確認用Deck",
+          quizIds: ["quiz-1"],
+          source: "manual_selection",
+        })
+        .expectStatus(200);
+      const deckId = createResponse.json.deck.id;
+
+      // When: GET /decks/mineで一覧取得
+      const response = await spec()
+        .get(`${BASE_PATH}/mine`)
+        .withCookies(COOKIE_NAME, fingerprint)
+        .expectStatus(200);
+
+      // Then: 一覧に作成したDeckのIDが含まれる（PaginationResponse<Deck>形式）
+      const body = response.json;
+      expect(body).toHaveProperty("items");
+      expect(body).toHaveProperty("totalCount");
+      expect(body).toHaveProperty("hasMore");
+      const foundDeck = body.items.find(
+        (item: Record<string, unknown>) => item["id"] === deckId,
+      );
+      expect(foundDeck).toBeDefined();
+    });
+  });
+
+  describe("検索結果からDeck生成: POST /decks/from-search", () => {
+    it("検索にヒットした問題からDeckを生成できる", async () => {
+      // Given: MockSearchRepositoryにヒットするキーワード
+
+      // When: POST /decks/from-searchを実行
+      const response = await spec()
+        .post(`${BASE_PATH}/from-search`)
+        .withJson({ searchQuery: "JavaScript", maxQuizzes: 10 })
+        .expectStatus(200);
+
+      // Then: 検索結果を含むDeckが生成される
+      expect(response.json.deck.quizIds.length).toBeGreaterThan(0);
+    });
+
+    it("検索結果が0件の場合はエラーを返す", async () => {
+      // Given: ヒットしないキーワード
+
+      // When: POST /decks/from-searchを実行
+      const response = await spec()
+        .post(`${BASE_PATH}/from-search`)
+        .withJson({
+          searchQuery: "絶対にヒットしないはずのキーワードxyz123",
+        })
+        .expectStatus(500);
+
+      // Then: エラーレスポンスが返る
+      expect(response.json).toHaveProperty("code");
+    });
+  });
+
+  describe("間違い問題からDeck生成: POST /decks/wrong-questions", () => {
+    it("間違い問題が0件の場合はエラーを返す（Attempt未実装のため常に空）", async () => {
+      // Given: MockAttemptQueryRepositoryはデフォルトで空
+
+      // When: POST /decks/wrong-questionsを実行
+      const response = await spec()
+        .post(`${BASE_PATH}/wrong-questions`)
+        .withJson({})
+        .expectStatus(500);
+
+      // Then: エラーレスポンスが返る
+      expect(response.json).toHaveProperty("code");
+    });
+  });
+});

--- a/api/tests/fixtures/deck-management-data.ts
+++ b/api/tests/fixtures/deck-management-data.ts
@@ -1,0 +1,24 @@
+// Deck Management test data for PactumJS specs
+// issue #47（quiz-learning Deck管理）
+
+export const deckManagementData = {
+  // Deck新規作成の正常系シナリオ
+  createDeckScenarios: [
+    {
+      description: "name/description省略・単一quizId",
+      requestBody: {
+        quizIds: ["quiz-1"],
+        source: "manual_selection",
+      },
+    },
+    {
+      description: "name/description指定・複数quizId",
+      requestBody: {
+        name: "JavaScript基礎問題集",
+        description: "配列・オブジェクト操作の基本",
+        quizIds: ["quiz-1", "quiz-2", "quiz-3"],
+        source: "manual_selection",
+      },
+    },
+  ],
+} as const;

--- a/docs/project/adr/0027-deck-api-ownership-and-surface-adjustments.md
+++ b/docs/project/adr/0027-deck-api-ownership-and-surface-adjustments.md
@@ -1,0 +1,122 @@
+# ADR-0027: quiz-learning Deck API の所有者解決とAPIサーフェス調整
+
+## Status
+
+Proposed
+
+## Context
+
+### Background
+
+issue #47（Epic #60）は空の `quiz-learning` コンテキストに Deck（問題集）集約を 4 層 DDD で実装することを求めている。完了条件には `PATCH /decks/:id` と `GET /decks`（一覧）が挙げられているが、調査の結果、以下のギャップが判明した。
+
+1. `api/spec/operations/quiz-learning.tsp` の Deck 関連 operation は `createDeck` / `createDeckFromSearch` / `createDeckFromWrongAnswers` / `getDeck` / `getMyDecks` / `deleteDeck` の6本のみで、`updateDeck`（PATCH）が定義されていない。ADR-0025 が定めた PATCH 統一（PR #61）は quiz-management・quiz-learning の sessions・user-session のみを対象とし、Deck は対象外だった。
+2. 汎用の `GET /decks`（一覧）は TypeSpec にも API カタログ（`docs/project/api-design/api-catalog/02-quiz-learning.md`）にも存在しない。存在するのは `GET /decks/mine`（`@query userId: UserId` 必須）のみ。
+3. `getMyDecks` の `userId` クエリと `createDeckFromWrongAnswers` の `userId` ボディは、任意の `UserId` を指定すれば他人の Deck 一覧・間違い問題を取得できてしまう設計になっている。一方 ADR-0026（issue #44 / PR #63）により `anonymousSession` ミドルウェアが全リクエストに `c.var.userFingerprint` を供給する基盤が既に存在する。
+4. `Deck.creator_id` は D1 上 `INTEGER FK → UserIdentity.id` だが、`userFingerprint` は `UserIdentity.anonymous_id`（UUID文字列）であり、両者を橋渡しする解決処理（ADR-0026 が `resolveUserIdentity` として「後続実装」に位置づけたもの）がまだ存在しない。
+5. `DeckListResponse` は `PaginationResponse<DeckWithQuizzes>` で定義されており、一覧1件ごとに紐づく全問題（`QuizResponse[]`、各Deck最大100件・`maxQuizzes`のデフォルト）を丸ごと埋め込む形になっている。
+
+### Drivers
+
+- ADR-0026 が確立した「`userFingerprint` を匿名ユーザーの識別子の正とする」方針との整合性
+- `docs/instructions/shared/workflow/00.02_workflow.md` が求める、API設計方針の重要決定に関するADR記録
+- N+1的な巨大レスポンスを避け、一覧取得のレイテンシとペイロードサイズを抑える必要性
+- issue #47 のスコープを「Deck管理」に閉じ、Session/Answer（次issue）や user-session コンテキストのフル実装（issue #44 後続分）まで広げないこと
+
+## Decision
+
+### Chosen Option
+
+**(1) `updateDeck`（PATCH）をADR-0025の判断基準に従い新規追加する。(2) `userId`パラメータを撤廃し`userFingerprint`を所有者の唯一の正とする。(3) 汎用`GET /decks`は新設せず`GET /decks/mine`で代替する。(4) `resolveUserIdentity`を独立したポート（`IUserIdentityResolver`）として実装し、Deckのuse-caseから直接注入する。(5) `DeckListResponse`を`PaginationResponse<Deck>`に軽量化する。**
+
+#### (1) updateDeck の追加
+
+`UpdateDeckRequest { name?; description?; quizIds?; }` を `deck.tsp` に追加し、`@patch(#{ implicitOptionality: false })` で `updateDeck` を定義する。ADR-0025 の判断基準表「既存リソースの部分更新（フィールド単位の変更）→PATCH」に合致する。
+
+#### (2)(3) userId撤廃・GET /decks/mine で一覧要件を満たす
+
+`getMyDecks` の `@query userId: UserId` と `createDeckFromWrongAnswers` の body `userId: UserId` を削除し、両ハンドラーは常に `c.var.userFingerprint` から解決した所有者IDを使う。任意の他人のDeckを覗ける設計上の穴を構造的に防ぐ。汎用一覧 `GET /decks` は、匿名ユーザー前提のアプリで他人のDeckを全件列挙する用途が想定しにくいため新設せず、「一覧」要件は `GET /decks/mine` で満たしたものとする。
+
+#### (4) resolveUserIdentity の実装方針
+
+ADR-0026 は `c.var.resolveUserIdentity()` をミドルウェアが注入する形を将来像として示唆していたが、本PRでは **ミドルウェア（`api/src/middleware/anonymousSession.ts`）自体は変更せず**、独立したポートとして実装する。
+
+- `api/src/shared/identity/IUserIdentityResolver.ts`: `resolve(anonymousId: string): ResultAsync<string, RepositoryError>`（戻り値は `UserIdentity.id` の文字列化）
+- `api/src/infrastructure/identity/D1UserIdentityResolver.ts`: `SELECT id FROM UserIdentity WHERE anonymous_id = ?`、無ければ `INSERT` して `last_row_id` を採番
+- `api/src/infrastructure/identity/MockUserIdentityResolver.ts`: fingerprintをそのまま識別子として返す（モック環境はINTEGER FK制約を持たないため）
+- `api/src/infrastructure/identity/UserIdentityResolverFactory.ts`: `QuizRepositoryFactory.shouldUseMock()` を再利用しD1/Mockを切替
+
+理由: 本PRの並行作業（issue #46: quiz-management PATCH実装、issue #48: Search D1接続）が `anonymousSession.ts` や `user-session` コンテキストに触れる可能性があり、ミドルウェア自体の変更は衝突リスクを高める。ポートとして独立させることで、issue #47 のスコープ（Deck管理）に変更を閉じつつ、ADR-0026 が示した「D1アクセスは必要なhandlerだけに限定する」という遅延解決の精神は維持する。将来 `user-session` コンテキストが本格実装される際（ADR-0026 Action Items）、この `IUserIdentityResolver` を `contexts/user-session/domain/repositories/` 配下に昇格・統合するか、ミドルウェア注入方式に置き換えるかを別途判断する。
+
+#### (5) DeckListResponse の軽量化
+
+`DeckListResponse` を `PaginationResponse<Deck>` に変更する。詳細（紐づく問題本体）は `GET /decks/{id}`（`DeckWithQuizzes`）で個別に取得する設計とする。
+
+### Alternatives Considered
+
+| 選択肢 | メリット | デメリット | 評価 |
+|--------|----------|------------|------|
+| `userId` パラメータをTypeSpec通り維持 | 生成型と完全一致、変更が最小 | 誰でも他人のDeck一覧・間違い問題を取得できる設計上の欠陥が残る | ★ |
+| 汎用 `GET /decks` を新設（全ユーザー横断一覧） | issue本文の文言に最も忠実 | 匿名ユーザー前提のアプリで「他人のDeckを全件列挙する」用途が不明瞭。権限設計も要検討になりスコープが拡大する | ★★ |
+| `resolveUserIdentity` をミドルウェア注入方式（ADR-0026当初案）で実装 | ADR-0026の将来像と完全に一致、`c.var`から直接呼べる | `anonymousSession.ts`本体の変更が必要になり、並行issue（#44後続, #46, #48）との衝突リスクが増す | ★★ |
+| **独立ポート`IUserIdentityResolver`として実装（採用）** | **既存の`QuizRepositoryFactory`パターンと一貫、ミドルウェアに触れず衝突リスクを最小化、将来の昇格も容易** | **将来ミドルウェア注入方式に統合する場合は追加の移行作業が発生する** | **★★★** |
+| `DeckListResponse` を `DeckWithQuizzes` のまま維持 | TypeSpec変更が不要 | 一覧20件で数百問分の`QuizResponse`が乗る巨大レスポンス、N+1的なD1アクセスが発生する | ★ |
+
+## Consequences
+
+### Positive
+
+- Deck の所有者確認が構造的に `userFingerprint` 一本化され、他人のDeckを覗ける穴がなくなる
+- `PATCH /decks/:id` が issue #47 の完了条件を満たす
+- `resolveUserIdentity` が独立ポートとして実装され、将来 issue #46（quiz-management の creatorId 解決）等でも再利用可能になる
+- `DeckListResponse` の軽量化により一覧取得のレイテンシとペイロードサイズが抑えられる
+
+### Negative
+
+- TypeSpec の `CreateDeckFromSearchRequest`・API カタログドキュメントとの間に既存の乖離（`creatorFingerprint`必須 vs 実際は本文パラメータなし）が残る。本PRでは`userFingerprint`をミドルウェア経由で扱うため実害はないが、API カタログドキュメントの更新は本ADRのスコープ外とする
+- `resolveUserIdentity` をミドルウェア注入方式にしなかったことで、ADR-0026の元々の設計（Action Items）から一部逸脱する。将来の統合作業が別途必要になる
+
+### Neutral
+
+- Session/Answer（`startSession`等）は本PRの対象外のまま。TypeSpec上は既に定義されているが、Honoハンドラーは未実装のまま残る
+- `createDeckFromSearch` は既存 `search` コンテキストの `SearchQuizzesUseCase`（Mock実装、issue #48で D1 化予定）をそのまま注入・再利用する
+
+### Risks and Mitigation
+
+| リスク | 発生確率 | 影響度 | 対策 |
+|--------|----------|--------|------|
+| `IUserIdentityResolver` と将来の `user-session` コンテキスト実装が重複・分岐する | 中 | 低 | 本ADRのNegativeに明記し、issue #44後続タスクのレビュー時に統合判断を促す |
+| API カタログドキュメント（`02-quiz-learning.md`）が本ADRの変更を反映せず古いまま残る | 高 | 低 | 別issueでのドキュメント整合タスクとして起票を推奨（本PRのスコープ外） |
+
+## Implementation Notes
+
+### Action Items
+
+- [x] `api/spec/models/deck.tsp`: `UpdateDeckRequest` 追加、`DeckListResponse` を `PaginationResponse<Deck>` に変更
+- [x] `api/spec/operations/quiz-learning.tsp`: `updateDeck` 追加、`getMyDecks`/`createDeckFromWrongAnswers` から `userId` 削除
+- [ ] `api/src/shared/identity/IUserIdentityResolver.ts` ＋ D1/Mock実装 ＋ Factory
+- [ ] `api/src/contexts/quiz-learning/` 4層実装（domain/application/infrastructure/presentation）
+- [ ] `api/src/index.ts` に `learningRoutes` を配線
+- [ ] BDDテスト（`api/tests/features/deck-management.spec.ts`）
+
+### Timeline
+
+- **決定日**: 2026-08-13
+- **実装開始**: 2026-08-13
+- **完了予定**: 本PR内
+
+## References
+
+- issue #47, #44, #46, #48
+- Epic #60
+- ADR-0025（更新系エンドポイントのHTTPメソッド方針）
+- ADR-0026（匿名ユーザー識別方式選定）
+- ADR-0019（リポジトリパターン採用決定）
+- `docs/project/api-design/api-catalog/02-quiz-learning.md`
+
+---
+
+**Created**: 2026-08-13
+**Last Updated**: 2026-08-13
+**Authors**: Claude (Opus 5, background session)
+**Reviewers**: [@tanacchi](https://github.com/tanacchi)

--- a/docs/project/adr/0028-deck-api-ownership-and-surface-adjustments.md
+++ b/docs/project/adr/0028-deck-api-ownership-and-surface-adjustments.md
@@ -1,4 +1,4 @@
-# ADR-0027: quiz-learning Deck API の所有者解決とAPIサーフェス調整
+# ADR-0028: quiz-learning Deck API の所有者解決とAPIサーフェス調整
 
 ## Status
 

--- a/docs/project/adr/README.md
+++ b/docs/project/adr/README.md
@@ -32,6 +32,7 @@
 | [0024](0024-accessibility-policy.md) | アクセシビリティ方針（WCAG 2.1 AA目標） | Proposed | 2025-08-11 | WCAG 2.1 レベルAAを目標として確定 |
 | [0025](0025-update-endpoint-http-method-policy.md) | 更新系エンドポイントのHTTPメソッド方針 | Proposed | 2026-08-12 | TypeSpec/Hono実装層でのPATCH/POST判断基準を確定 |
 | [0026](0026-anonymous-user-identification-strategy.md) | 匿名ユーザー識別方式選定 | Proposed | 2026-08-11 | Cookie + UUID v4 + ミドルウェア + 遅延解決採用 |
+| [0027](0027-deck-api-ownership-and-surface-adjustments.md) | quiz-learning Deck API の所有者解決とAPIサーフェス調整 | Proposed | 2026-08-13 | updateDeck追加・userFingerprint一本化・一覧軽量化 |
 
 ## ステータス定義
 
@@ -67,5 +68,5 @@
 ---
 
 **作成日**: 2025-07-28  
-**最終更新**: 2025-08-11  
+**最終更新**: 2026-08-13  
 **管理者**: [@tanacchi](https://github.com/tanacchi)


### PR DESCRIPTION
## 概要

Closes #47

現在完全に空だった `quiz-learning` コンテキストに Deck（問題集）集約を4層 DDD で実装し、CRUD ＋「検索結果から生成」「間違い問題から生成」の7エンドポイントを提供する。

## 実装前の調査で判明したギャップと対応方針（ADR-0027参照）

issue完了条件と既存TypeSpec/APIカタログの間に以下の乖離があったため、ADR-0027として設計判断を記録した上で対応した。

- `PATCH /decks/:id` が TypeSpec に未定義 → `UpdateDeckRequest` と `updateDeck` operation を新規追加（ADR-0025のPATCH判断基準に合致）
- 汎用の `GET /decks`（一覧）が未定義 → 既存の `GET /decks/mine` で「一覧」要件を満たす
- `getMyDecks`/`createDeckFromWrongAnswers` の `userId` パラメータが「任意の他人のDeckを覗ける」設計だった → 削除し、`anonymousSession` ミドルウェア（ADR-0026）が発行する `c.var.userFingerprint` を所有者の唯一の正とする
- `Deck.creator_id`（D1上はUserIdentity.id へのINTEGER FK）と `userFingerprint`（UUID文字列）を橋渡しする `resolveUserIdentity` がADR-0026で「後続実装」のまま未着手だった → `IUserIdentityResolver` を独立ポートとして実装
- `DeckListResponse` が `PaginationResponse<DeckWithQuizzes>`（一覧で全問題本体を返す設計）だった → `PaginationResponse<Deck>` に軽量化

## 実装内容

### TypeSpec / ADR
- `updateDeck` operation・`UpdateDeckRequest` モデル追加、`DeckListResponse` 軽量化、`userId` パラメータ削除
- ADR-0027 新規作成（上記の設計判断を記録）

### resolveUserIdentity
- `IUserIdentityResolver` / `D1UserIdentityResolver` / `MockUserIdentityResolver` / `UserIdentityResolverFactory`
- ミドルウェア本体（`anonymousSession.ts`）には手を入れず独立ポートとして実装（並行issue #46/#48との衝突回避）

### Deck集約（4層）
- **domain**: `Deck` エンティティ（quiz-managementのTag/Quizと同じschema+EntityBase継承パターン）、`IDeckRepository`、`IAttemptQueryRepository`（間違い問題生成専用の読み取り専用ポート）
- **application**: 7ユースケース（Create/CreateFromSearch/CreateFromWrongAnswers/Get/GetMy/Update/Delete）。`CreateDeckFromSearchUseCase` は既存 `search` コンテキストの `SearchQuizzesUseCase` を再利用
- **infrastructure**: `D1DeckRepository`/`MockDeckRepository`、`D1AttemptQueryRepository`/`MockAttemptQueryRepository`、対応するFactory
- **presentation**: `DeckController`（7メソッド）、`learning.routes.ts`（Honoルーター）、TypeSpec契約に`satisfies`制約したZodスキーマ

### 配線・テスト
- `api/src/index.ts` に `/api/quiz/v1/learning` へのマウント追加
- Unit/統合テスト 99件、BDDテスト（Pactum、wrangler dev実結合）10件

## 実装中に発見・修正した問題

Cloudflare Workersはリクエストごとにハンドラーが呼ばれるため、`createDeckRepository` が毎回 `new MockDeckRepository()` を返すとモック環境でリクエストを跨いだデータ永続性が失われる（作成直後のGETが404になる）ことが統合テストで判明。`DeckRepositoryFactory` をモジュールスコープのシングルトンに変更し、テスト用に `resetMockDeckRepository()` を追加した。

## テスト

- [x] `pnpm --filter api typecheck` 通過
- [x] `pnpm lint` 通過（biome + markdownlint、317ファイル）
- [x] `pnpm test` 通過（TDD 1063件 + BDD 206件 + UI/scripts、全緑）
- [x] `pnpm build` 通過（TypeSpec再生成 + Next.jsビルド含む）

## 依存関係

- #40（TypeSpec整合）: 解決済み
- #44（認証ミドルウェア）: 解決済み（PR #63でマージ済み）

## スコープ外

Session/Answer（学習セッション管理、回答提出）は次issueのスコープ。`POST /decks/wrong-questions` は既存の `Attempt` テーブルを読み取り専用で参照するのみで、Session/Answer集約自体は実装していない。